### PR TITLE
Add vendor profile page and dynamic sidebar link

### DIFF
--- a/app/Http/Controllers/Vendor/ProfileController.php
+++ b/app/Http/Controllers/Vendor/ProfileController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class ProfileController extends Controller
+{
+    /**
+     * Show the profile edit form.
+     */
+    public function edit(Request $request)
+    {
+        return view('vendor.profile.edit');
+    }
+
+    /**
+     * Update the authenticated user's profile information.
+     */
+    public function update(Request $request)
+    {
+        $validated = $request->validate([
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+            'company' => ['nullable', 'string', 'max:255'],
+            'country' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $user = $request->user();
+        $user->update($validated);
+
+        return redirect()->route('profile')->with('status', 'Profile updated successfully.');
+    }
+}

--- a/resources/views/vendor/layouts/partials/sidebar.blade.php
+++ b/resources/views/vendor/layouts/partials/sidebar.blade.php
@@ -11,7 +11,7 @@
 
   <!-- NEW MENU -->
   <nav class="nav flex-column gap-1" id="mainNav">
-    <a class="nav-link " href="">
+    <a class="nav-link " href="{{ route('dashboard') }}">
       <i class="bi bi-speedometer2"></i> <span>Dashboard</span>
     </a>
     <a class="nav-link " href="">
@@ -33,7 +33,7 @@
       <span class="ms-auto"><i class="bi bi-caret-down-fill"></i></span>
     </a>
     <div class="collapse subnav " id="settingsMenu" data-bs-parent="#mainNav">
-      <a class="nav-link " href="">
+      <a class="nav-link " href="{{ route('profile') }}">
         <i class="bi bi-person me-1"></i> <span>Profile</span>
       </a>
       <a class="nav-link " href="">
@@ -47,7 +47,7 @@
   </nav>
 
   <div class="bottom">
-    <form method="POST" action="">
+    <form method="POST" action="{{ route('logout') }}">
       @csrf
       <button type="submit" class="logout">
         <i class="bi bi-box-arrow-right"></i> <span>Logout</span>

--- a/resources/views/vendor/profile/edit.blade.php
+++ b/resources/views/vendor/profile/edit.blade.php
@@ -1,0 +1,65 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'Profile')
+
+@section('content')
+  <div class="bw-band">
+    <ol class="bw-crumb">
+      <li><a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i>Home</a></li>
+      <li>Profile</li>
+    </ol>
+  </div>
+
+  <div class="container py-4">
+    <div class="row mb-4 align-items-center">
+      <div class="col-auto">
+        <div class="avatar-circle">{{ \Illuminate\Support\Str::of(auth()->user()->first_name)->substr(0,1) }}{{ \Illuminate\Support\Str::of(auth()->user()->last_name)->substr(0,1) }}</div>
+      </div>
+      <div class="col">
+        <h2 class="mb-0">{{ auth()->user()->first_name }} {{ auth()->user()->last_name }}</h2>
+        <div class="text-muted">{{ auth()->user()->country }}</div>
+      </div>
+    </div>
+
+    @if (session('status'))
+      <div class="alert alert-success">{{ session('status') }}</div>
+    @endif
+
+    <form method="POST" action="{{ route('profile.update') }}">
+      @csrf
+      @method('PUT')
+
+      <div class="row mb-3">
+        <div class="col-md-6">
+          <label class="form-label">First Name</label>
+          <input type="text" name="first_name" class="form-control" value="{{ old('first_name', auth()->user()->first_name) }}">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Last Name</label>
+          <input type="text" name="last_name" class="form-control" value="{{ old('last_name', auth()->user()->last_name) }}">
+        </div>
+      </div>
+
+      <div class="row mb-3">
+        <div class="col-md-6">
+          <label class="form-label">Company</label>
+          <input type="text" name="company" class="form-control" value="{{ old('company', auth()->user()->company) }}">
+        </div>
+        <div class="col-md-6">
+          <label class="form-label">Country</label>
+          <input type="text" name="country" class="form-control" value="{{ old('country', auth()->user()->country) }}">
+        </div>
+      </div>
+
+      <div class="mb-3">
+        <label class="form-label">Email</label>
+        <input type="email" class="form-control" value="{{ auth()->user()->email }}" disabled>
+      </div>
+
+      <div class="d-flex gap-2">
+        <button type="submit" class="btn btn-primary">Save</button>
+        <button type="reset" class="btn btn-secondary">Reset</button>
+      </div>
+    </form>
+  </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,7 +6,8 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\NewsletterSubscriptionController;
 use App\Http\Controllers\Vendor\DashboardController;
-use App\Http\Controllers\ContactController; 
+use App\Http\Controllers\Vendor\ProfileController;
+use App\Http\Controllers\ContactController;
 use App\Http\Controllers\PartnershipsController;
 
 Route::middleware('guest')->group(function () {
@@ -44,4 +45,6 @@ Route::post('/partnerships', [PartnershipsController::class, 'store'])->name('pa
 // Vendor dashboard
 Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
+    Route::get('profile', [ProfileController::class, 'edit'])->name('profile');
+    Route::put('profile', [ProfileController::class, 'update'])->name('profile.update');
 });


### PR DESCRIPTION
## Summary
- add vendor profile controller and routes
- create profile edit page
- wire sidebar links and logout through named routes

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b6afd9a74883279b15d34739136e49