### PR TITLE
Add profile link in vendor header

### DIFF
--- a/resources/views/vendor/layouts/partials/header.blade.php
+++ b/resources/views/vendor/layouts/partials/header.blade.php
@@ -55,7 +55,7 @@
         <i class="bi bi-person-circle"></i>
       </button>
       <ul class="dropdown-menu dropdown-menu-end user-menu shadow-sm mt-2">
-        <li><a class="dropdown-item d-flex align-items-center" href="#"><i class="bi bi-person me-2"></i> Profile</a></li>
+        <li><a class="dropdown-item d-flex align-items-center" href="{{ route('profile') }}"><i class="bi bi-person me-2"></i> Profile</a></li>
         <li><a class="dropdown-item d-flex align-items-center" href="#"><i class="bi bi-key me-2"></i> Change Password</a></li>
         <li><hr class="dropdown-divider"></li>
         <li>


### PR DESCRIPTION
## Summary
- Link vendor header profile menu item to profile page

## Testing
- `phpunit` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b192ff448327a8498a337e005b1c