### PR TITLE
Implement AJAX profile and password updates

### DIFF
--- a/app/Http/Controllers/Vendor/PasswordController.php
+++ b/app/Http/Controllers/Vendor/PasswordController.php
@@ -29,6 +29,11 @@ class PasswordController extends Controller
         $request->user()->update([
             'password' => Hash::make($validated['password']),
         ]);
+        if ($request->expectsJson()) {
+            return response()->json([
+                'status' => 'Password updated successfully.'
+            ]);
+        }
 
         return redirect()->route('password.edit')->with('status', 'Password updated successfully.');
     }

--- a/app/Http/Controllers/Vendor/ProfileController.php
+++ b/app/Http/Controllers/Vendor/ProfileController.php
@@ -29,6 +29,11 @@ class ProfileController extends Controller
 
         $user = $request->user();
         $user->update($validated);
+        if ($request->expectsJson()) {
+            return response()->json([
+                'status' => 'Profile updated successfully.'
+            ]);
+        }
 
         return redirect()->route('profile')->with('status', 'Profile updated successfully.');
     }

--- a/resources/views/vendor/password/edit.blade.php
+++ b/resources/views/vendor/password/edit.blade.php
@@ -95,13 +95,11 @@
 
   <div class="container py-4">
     <div class="card-xl mb-4">
-      @if (session('status'))
-        <div class="alert alert-success mb-3">{{ session('status') }}</div>
-      @endif
+      <div id="password-alert" class="alert mb-3 d-none"></div>
 
       <h5 class="mb-3" style="font-weight:700;color:#111827;">Change Password</h5>
 
-      <form method="POST" action="{{ route('password.update') }}">
+      <form id="password-form" method="POST" action="{{ route('password.update') }}">
         @csrf
         @method('PUT')
 
@@ -154,6 +152,66 @@
       this.classList.toggle('bi-eye');
       this.classList.toggle('bi-eye-slash');
     });
+  });
+
+  const passwordForm = document.getElementById('password-form');
+  const passwordAlert = document.getElementById('password-alert');
+
+  passwordForm.addEventListener('submit', async function(e) {
+    e.preventDefault();
+    passwordAlert.classList.add('d-none');
+    passwordAlert.classList.remove('alert-success', 'alert-danger');
+
+    const current = passwordForm.current_password.value.trim();
+    const pass = passwordForm.password.value.trim();
+    const confirm = passwordForm.password_confirmation.value.trim();
+
+    if (!current || !pass || !confirm) {
+      passwordAlert.textContent = 'All fields are required.';
+      passwordAlert.classList.add('alert', 'alert-danger');
+      passwordAlert.classList.remove('d-none');
+      return;
+    }
+
+    if (pass.length < 8) {
+      passwordAlert.textContent = 'Password must be at least 8 characters.';
+      passwordAlert.classList.add('alert', 'alert-danger');
+      passwordAlert.classList.remove('d-none');
+      return;
+    }
+
+    if (pass !== confirm) {
+      passwordAlert.textContent = 'Passwords do not match.';
+      passwordAlert.classList.add('alert', 'alert-danger');
+      passwordAlert.classList.remove('d-none');
+      return;
+    }
+
+    const formData = new FormData(passwordForm);
+    try {
+      const response = await fetch(passwordForm.action, {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        body: formData
+      });
+      const data = await response.json();
+      if (response.ok) {
+        passwordAlert.textContent = data.status || 'Password updated successfully.';
+        passwordAlert.classList.add('alert', 'alert-success');
+        passwordForm.reset();
+      } else if (response.status === 422) {
+        passwordAlert.textContent = Object.values(data.errors).join(' ');
+        passwordAlert.classList.add('alert', 'alert-danger');
+      } else {
+        passwordAlert.textContent = 'An error occurred.';
+        passwordAlert.classList.add('alert', 'alert-danger');
+      }
+      passwordAlert.classList.remove('d-none');
+    } catch (error) {
+      passwordAlert.textContent = 'An error occurred.';
+      passwordAlert.classList.add('alert', 'alert-danger');
+      passwordAlert.classList.remove('d-none');
+    }
   });
 </script>
 @endpush

--- a/resources/views/vendor/profile/edit.blade.php
+++ b/resources/views/vendor/profile/edit.blade.php
@@ -120,13 +120,11 @@
 
       <div class="section-line"></div>
 
-      @if (session('status'))
-        <div class="alert alert-success mb-3">{{ session('status') }}</div>
-      @endif
+      <div id="profile-alert" class="alert mb-3 d-none"></div>
 
       <h5 class="mb-3" style="font-weight:700;color:#111827;">Edit Profile</h5>
 
-      <form method="POST" action="{{ route('profile.update') }}">
+      <form id="profile-form" method="POST" action="{{ route('profile.update') }}">
         @csrf
         @method('PUT')
 
@@ -175,3 +173,52 @@
     </div>
   </div>
 @endsection
+
+@push('scripts')
+<script>
+  const profileForm = document.getElementById('profile-form');
+  const profileAlert = document.getElementById('profile-alert');
+
+  profileForm.addEventListener('submit', async function(e) {
+    e.preventDefault();
+    profileAlert.classList.add('d-none');
+    profileAlert.classList.remove('alert-success', 'alert-danger');
+
+    const firstName = profileForm.first_name.value.trim();
+    const lastName = profileForm.last_name.value.trim();
+
+    if (!firstName || !lastName) {
+      profileAlert.textContent = 'First and last name are required.';
+      profileAlert.classList.add('alert', 'alert-danger');
+      profileAlert.classList.remove('d-none');
+      return;
+    }
+
+    const formData = new FormData(profileForm);
+    try {
+      const response = await fetch(profileForm.action, {
+        method: 'POST',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+        body: formData
+      });
+
+      const data = await response.json();
+      if (response.ok) {
+        profileAlert.textContent = data.status || 'Profile updated successfully.';
+        profileAlert.classList.add('alert', 'alert-success');
+      } else if (response.status === 422) {
+        profileAlert.textContent = Object.values(data.errors).join(' ');
+        profileAlert.classList.add('alert', 'alert-danger');
+      } else {
+        profileAlert.textContent = 'An error occurred.';
+        profileAlert.classList.add('alert', 'alert-danger');
+      }
+      profileAlert.classList.remove('d-none');
+    } catch (error) {
+      profileAlert.textContent = 'An error occurred.';
+      profileAlert.classList.add('alert', 'alert-danger');
+      profileAlert.classList.remove('d-none');
+    }
+  });
+</script>
+@endpush


### PR DESCRIPTION
## Summary
- Return JSON from profile and password controllers when requests expect JSON
- Add AJAX submission with basic JS validation for profile edit form
- Add AJAX submission with client-side checks for password change form

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b6b5bb4b6883279a27c769f48e8140