### PR TITLE
fix: ensure file upload sends csrf token

### DIFF
--- a/resources/views/vendor/files/index.blade.php
+++ b/resources/views/vendor/files/index.blade.php
@@ -265,6 +265,8 @@
       await fetch(routes.upload, {
         method: 'POST',
         body: fd,
+        headers: { 'X-CSRF-TOKEN': csrf },
+        credentials: 'same-origin',
       }).then(async (r)=>{
         if(!r.ok){ throw new Error((await r.json().catch(()=>({}))).message || 'Upload failed'); }
         return r.json();


### PR DESCRIPTION
## Summary
- fix vendor file upload by including CSRF header and sending credentials in fetch request

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b6c55049f483278c6707e78aaa886f