### PR TITLE
Add query-based PDF viewer link

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -112,8 +112,19 @@ class DocumentController extends Controller
         $doc->save();
 
         return response()->json([
-            'url' => route('vendor.files.public', $doc->share_token),
+            'url' => route('document.view', ['doc' => $doc->share_token]),
         ]);
+    }
+
+    /**
+     * Public access via query parameter (e.g. /view?doc=TOKEN)
+     */
+    public function view(Request $request)
+    {
+        $token = $request->query('doc');
+        abort_unless($token, 404);
+
+        return $this->public($token);
     }
 
     // public access by token (simple inline view)

--- a/core-php/view.php
+++ b/core-php/view.php
@@ -1,0 +1,36 @@
+<?php
+require __DIR__.'/../vendor/autoload.php';
+
+$app = require_once __DIR__.'/../bootstrap/app.php';
+$app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+
+use App\Models\Document;
+use Illuminate\Support\Carbon;
+
+$token = $_GET['doc'] ?? null;
+if (!$token) {
+    http_response_code(404);
+    exit('Missing document token');
+}
+
+$doc = Document::where('share_token', $token)->first();
+if (!$doc) {
+    http_response_code(404);
+    exit('Document not found');
+}
+
+if ($doc->share_expires_at && Carbon::now()->greaterThan($doc->share_expires_at)) {
+    http_response_code(410);
+    exit('Link expired');
+}
+
+$path = __DIR__.'/../public/'.$doc->filepath;
+if (!is_file($path)) {
+    http_response_code(404);
+    exit('File missing');
+}
+
+header('Content-Type: application/pdf');
+header('Content-Disposition: inline; filename="'.$doc->filename.'"');
+readfile($path);
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,4 +65,5 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
 });
 
 // Public viewer link (no auth)
+Route::get('/view', [DocumentController::class, 'view'])->name('document.view');
 Route::get('/s/{token}', [DocumentController::class, 'public'])->name('vendor.files.public');


### PR DESCRIPTION
## Summary
- Add `/view` route to serve PDFs by doc token
- Generate sharing links using new query parameter route
- Provide standalone `core-php/view.php` viewer script

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b6cf0388fc8327ba3d50f0f5877c8d