### PR TITLE
Add vendor analytics dashboard

### DIFF
--- a/app/Http/Controllers/Vendor/AnalyticsController.php
+++ b/app/Http/Controllers/Vendor/AnalyticsController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use App\Models\LinkAnalytics;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class AnalyticsController extends Controller
+{
+    /**
+     * Display basic analytics for the authenticated vendor.
+     */
+    public function index()
+    {
+        $user = Auth::user();
+
+        // Total analytics events for the user's documents in the last 7 days
+        $visits = LinkAnalytics::where('created_at', '>=', now()->subDays(7))
+            ->whereHas('link.document', function ($q) use ($user) {
+                $q->where('user_id', $user->id);
+            })
+            ->count();
+
+        // Top 5 documents by analytics events
+        $topDocs = DB::table('documents')
+            ->where('documents.user_id', $user->id)
+            ->leftJoin('links', 'links.document_id', '=', 'documents.id')
+            ->leftJoin('link_analytics', 'link_analytics.link_id', '=', 'links.id')
+            ->select('documents.filename', DB::raw('COUNT(link_analytics.id) as views'))
+            ->groupBy('documents.id', 'documents.filename')
+            ->orderByDesc('views')
+            ->limit(5)
+            ->get();
+
+        return view('vendor.analytics.index', [
+            'visits'  => $visits,
+            'topDocs' => $topDocs,
+        ]);
+    }
+}
+

--- a/resources/views/vendor/analytics/index.blade.php
+++ b/resources/views/vendor/analytics/index.blade.php
@@ -1,0 +1,84 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'Analytics')
+
+@section('content')
+<div class="container-fluid">
+  <div class="d-sm-flex align-items-center justify-content-between mb-4">
+    <h1 class="h3 mb-0 text-gray-800">Analytics</h1>
+  </div>
+
+  <div class="row">
+    <div class="col-xl-4 col-md-6 mb-4">
+      <div class="card border-left-primary shadow h-100 py-2">
+        <div class="card-body">
+          <div class="text-xs font-weight-bold text-primary text-uppercase mb-1">Visits (Last 7 Days)</div>
+          <div class="h5 mb-0 font-weight-bold text-gray-800">{{ $visits }}</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-xl-4 col-md-6 mb-4">
+      <div class="card border-left-success shadow h-100 py-2">
+        <div class="card-body">
+          <div class="text-xs font-weight-bold text-success text-uppercase mb-1">Average Reading Time</div>
+          <div class="h5 mb-0 font-weight-bold text-gray-800">N/A</div>
+        </div>
+      </div>
+    </div>
+    <div class="col-xl-4 col-md-6 mb-4">
+      <div class="card border-left-info shadow h-100 py-2">
+        <div class="card-body">
+          <div class="text-xs font-weight-bold text-info text-uppercase mb-1">Total Reading Time</div>
+          <div class="h5 mb-0 font-weight-bold text-gray-800">N/A</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="col-lg-6 mb-4">
+      <div class="card shadow mb-4">
+        <div class="card-header py-3">
+          <h6 class="m-0 font-weight-bold text-primary">Top 5 Documents</h6>
+        </div>
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-bordered mb-0">
+              <thead>
+                <tr>
+                  <th>Document</th>
+                  <th>Views</th>
+                </tr>
+              </thead>
+              <tbody>
+                @forelse ($topDocs as $doc)
+                <tr>
+                  <td>{{ $doc->filename }}</td>
+                  <td>{{ $doc->views }}</td>
+                </tr>
+                @empty
+                <tr>
+                  <td colspan="2" class="text-center">No data</td>
+                </tr>
+                @endforelse
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-lg-6 mb-4">
+      <div class="card shadow mb-4">
+        <div class="card-header py-3">
+          <h6 class="m-0 font-weight-bold text-primary">Top 5 Visitor Cities</h6>
+        </div>
+        <div class="card-body">
+          <p class="mb-0">Visitor location analytics are not available.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+@endsection
+

--- a/resources/views/vendor/layouts/partials/sidebar.blade.php
+++ b/resources/views/vendor/layouts/partials/sidebar.blade.php
@@ -20,7 +20,7 @@
     <a class="nav-link " href="{{ route('vendor.files.manage') }}">
       <i class="bi bi-folder2-open"></i> <span>Manage Files</span>
     </a>
-    <a class="nav-link " href="">
+    <a class="nav-link " href="{{ route('vendor.analytics.index') }}">
       <i class="bi bi-bar-chart"></i> <span>Analytics</span>
     </a>
     <a class="nav-link " href="">

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Vendor\PasswordController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\PartnershipsController;
 use App\Http\Controllers\Vendor\DocumentController; // files + public viewer
+use App\Http\Controllers\Vendor\AnalyticsController;
 
 /* ------------------------- Guest (auth) ------------------------- */
 Route::middleware('guest')->group(function () {
@@ -58,6 +59,8 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::post('files/upload',        [DocumentController::class, 'upload'])->name('vendor.files.upload');
     Route::post('files/delete',        [DocumentController::class, 'destroy'])->name('vendor.files.delete');
     Route::post('files/generate-link', [DocumentController::class, 'generateLink'])->name('vendor.files.generate');
+
+    Route::get('analytics',            [AnalyticsController::class, 'index'])->name('vendor.analytics.index');
 });
 
 /* ------------------------- Public viewer (no auth) ------------------------- */


### PR DESCRIPTION
## Summary
- add analytics controller to gather recent visit counts and top documents
- build vendor analytics Blade view
- expose analytics via route and sidebar link

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f68979b8832782001bdc1e74f40a