### PR TITLE
Track link creator in database

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -152,7 +152,8 @@ class DocumentController extends Controller
         $link = Link::firstOrNew(['document_id' => $doc->id]);
 
         if (!$link->exists) {
-            $link->slug = bin2hex(random_bytes(5)); // 10-char hex
+            $link->slug    = bin2hex(random_bytes(5)); // 10-char hex
+            $link->user_id = Auth::id();
         }
 
         // If your Link model doesn't cast 'permissions' => 'array',

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -12,6 +12,7 @@ class Link extends Model
 
     protected $fillable = [
         'document_id',
+        'user_id',
         'slug',
         'permissions',
         'created_at',
@@ -25,5 +26,10 @@ class Link extends Model
     public function document()
     {
         return $this->belongsTo(Document::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/database/migrations/2025_01_01_000000_create_links_table.php
+++ b/database/migrations/2025_01_01_000000_create_links_table.php
@@ -13,6 +13,7 @@ return new class extends Migration {
 
             $table->increments('id');
             $table->unsignedInteger('document_id')->index();
+            $table->unsignedInteger('user_id')->index();
             $table->string('slug', 20)->unique();
             $table->json('permissions');
             $table->timestamp('created_at')->useCurrent();


### PR DESCRIPTION
## Summary
- add `user_id` column to `links` table migration
- allow `Link` model to reference user and populate it when generating links

## Testing
- `APP_KEY=base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b6f891128883279f8e382b93371ff1