### PR TITLE
Limit manage files pagination to 10

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -52,7 +52,7 @@ class DocumentController extends Controller
             $query->where('filename', 'like', "%{$search}%");
         }
 
-        $docs = $query->latest()->paginate(25);
+        $docs = $query->latest()->paginate(10);
         $files = $docs->getCollection()->map(fn($d) => [
             'id'       => $d->id,
             'filename' => $d->filename,


### PR DESCRIPTION
## Summary
- show 10 files per page in vendor file manager

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b73f92ee288327863caa5c74f205cb