### PR TITLE
Add pagination to vendor file list

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -31,16 +31,22 @@ class DocumentController extends Controller
         $docs = Document::where('user_id', $user->id)
             ->with('link')
             ->latest()
-            ->get()
-            ->map(fn($d) => [
-                'id'       => $d->id,
-                'filename' => $d->filename,
-                'size'     => (int) $d->size,
-                'modified' => optional($d->updated_at)->format('Y-m-d H:i'),
-                'url'      => $d->link ? URL::to('/view').'?doc='.$d->link->slug : null,
-            ]);
+            ->paginate(10);
 
-        return response()->json(['files' => $docs]);
+        $files = $docs->getCollection()->map(fn($d) => [
+            'id'       => $d->id,
+            'filename' => $d->filename,
+            'size'     => (int) $d->size,
+            'modified' => optional($d->updated_at)->format('Y-m-d H:i'),
+            'url'      => $d->link ? URL::to('/view').'?doc='.$d->link->slug : null,
+        ]);
+
+        return response()->json([
+            'files'        => $files,
+            'current_page' => $docs->currentPage(),
+            'last_page'    => $docs->lastPage(),
+            'total'        => $docs->total(),
+        ]);
     }
 
     public function manageList(Request $request)


### PR DESCRIPTION
## Summary
- paginate vendor file listing and expose page metadata
- add frontend pagination UI and handlers

## Testing
- `./vendor/bin/phpunit` *(fails: No application encryption key has been specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7426547808327ba001e34fa7d74a5