### PR TITLE
Add Load More pagination to vendor dashboard

### DIFF
--- a/app/Http/Controllers/Vendor/DashboardController.php
+++ b/app/Http/Controllers/Vendor/DashboardController.php
@@ -16,26 +16,56 @@ class DashboardController extends Controller
     {
         $user = Auth::user();
 
-        $documents = Document::where('user_id', $user->id)
+        $docs = Document::where('user_id', $user->id)
             ->with('link')
             ->latest()
-            ->take(10)
-            ->get()
-            ->map(function ($doc) {
-                return [
-                    'id'       => $doc->id,
-                    'filename' => $doc->filename,
-                    'size'     => (int) $doc->size,
-                    'modified' => optional($doc->updated_at)->format('Y-m-d H:i:s'),
-                    'url'      => $doc->link ? URL::to('/view') . '?doc=' . $doc->link->slug : null,
-                ];
-            });
+            ->paginate(10);
 
-        $total = Document::where('user_id', $user->id)->count();
+        $files = $docs->getCollection()->map(function ($doc) {
+            return [
+                'id'       => $doc->id,
+                'filename' => $doc->filename,
+                'size'     => (int) $doc->size,
+                'modified' => optional($doc->updated_at)->format('Y-m-d H:i:s'),
+                'url'      => $doc->link ? URL::to('/view') . '?doc=' . $doc->link->slug : null,
+            ];
+        });
 
         return view('vendor.dashboard.index', [
-            'files' => $documents,
-            'total' => $total,
+            'files'        => $files,
+            'total'        => $docs->total(),
+            'current_page' => $docs->currentPage(),
+            'last_page'    => $docs->lastPage(),
+        ]);
+    }
+
+    /**
+     * Return paginated files for the dashboard (AJAX "Load More").
+     */
+    public function list()
+    {
+        $user = Auth::user();
+
+        $docs = Document::where('user_id', $user->id)
+            ->with('link')
+            ->latest()
+            ->paginate(10);
+
+        $files = $docs->getCollection()->map(function ($doc) {
+            return [
+                'id'       => $doc->id,
+                'filename' => $doc->filename,
+                'size'     => (int) $doc->size,
+                'modified' => optional($doc->updated_at)->format('Y-m-d H:i:s'),
+                'url'      => $doc->link ? URL::to('/view') . '?doc=' . $doc->link->slug : null,
+            ];
+        });
+
+        return response()->json([
+            'files'        => $files,
+            'current_page' => $docs->currentPage(),
+            'last_page'    => $docs->lastPage(),
+            'total'        => $docs->total(),
         ]);
     }
 }

--- a/resources/views/vendor/dashboard/index.blade.php
+++ b/resources/views/vendor/dashboard/index.blade.php
@@ -101,11 +101,31 @@ if (!function_exists('human_size')) {
         </tbody>
       </table>
     </div>
+    @if($last_page > 1)
+    <div class="card-footer text-center">
+      <button class="btn btn-dark" id="loadMoreBtn">Load More</button>
+    </div>
+    @endif
   </div>
 @endsection
 
 @push('scripts')
 <script>
+let currentPage = {{ $current_page ?? 1 }};
+const lastPage = {{ $last_page ?? 1 }};
+const listUrl = "{{ route('dashboard.list') }}";
+const manageUrl = "{{ route('vendor.files.manage') }}";
+
+function human_size(bytes) {
+  const units = ['B','KB','MB','GB','TB'];
+  let i = 0;
+  while (bytes >= 1024 && i < units.length - 1) {
+    bytes /= 1024;
+    i++;
+  }
+  return (i ? bytes.toFixed(2) : bytes) + ' ' + units[i];
+}
+
 document.getElementById('searchInput').addEventListener('input', function(){
   const q = this.value.toLowerCase();
   document.querySelectorAll('#filesTbody tr').forEach(function(tr){
@@ -124,5 +144,56 @@ document.addEventListener('click', function(e){
     }, 2000);
   });
 });
+
+function renderRow(file){
+  const parts = (file.modified || '').split(' ');
+  const date = parts[0] || '';
+  const time = parts[1] || '';
+  return `
+    <tr data-name="${file.filename.toLowerCase()}">
+      <td><input class="form-check-input" type="checkbox" /></td>
+      <td>
+        <div class="col-file">
+          <span class="file-chip"><i class="bi bi-file-earmark"></i></span>
+          <div class="file-name"><a href="${file.url || '#'}" target="_blank">${file.filename}</a></div>
+        </div>
+      </td>
+      <td>${human_size(file.size)}</td>
+      <td><div>${date}</div><small class="text-muted">${time}</small></td>
+      <td><span class="status-pill">${file.url ? 'Secure' : '—'}</span></td>
+      <td class="text-nowrap">
+        ${file.url ? `
+          <div class="d-flex gap-2 mb-2">
+            <button class="btn btn-ghost flex-fill copy-btn" data-url="${file.url}"><i class="bi bi-clipboard me-1"></i>Copy</button>
+            <a href="${file.url}" target="_blank" class="btn btn-ghost flex-fill"><i class="bi bi-box-arrow-up-right me-1"></i>Open</a>
+          </div>
+          <div class="small text-break text-muted">${file.url}</div>
+        ` : `
+          <a href="${manageUrl}" class="btn btn-ghost flex-fill"><i class="bi bi-link-45deg me-1"></i>Generate</a>
+        `}
+      </td>
+    </tr>
+  `;
+}
+
+const loadMoreBtn = document.getElementById('loadMoreBtn');
+if(loadMoreBtn){
+  if(currentPage >= lastPage){
+    loadMoreBtn.style.display = 'none';
+  }
+  loadMoreBtn.addEventListener('click', function(){
+    fetch(listUrl + '?page=' + (currentPage + 1))
+      .then(res => res.json())
+      .then(data => {
+        data.files.forEach(file => {
+          document.getElementById('filesTbody').insertAdjacentHTML('beforeend', renderRow(file));
+        });
+        currentPage = data.current_page;
+        if(currentPage >= data.last_page){
+          loadMoreBtn.style.display = 'none';
+        }
+      });
+  });
+}
 </script>
 @endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,7 @@ Route::post('/partnerships', [PartnershipsController::class, 'store'])->name('pa
 /* ------------------------- Vendor dashboard ------------------------- */
 Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
+    Route::get('dashboard/list', [DashboardController::class, 'list'])->name('dashboard.list');
 
     Route::get('profile', [ProfileController::class, 'edit'])->name('profile');
     Route::put('profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## Summary
- paginate vendor dashboard files and expose JSON endpoint for AJAX loading
- add Load More button with client-side fetching/appending logic
- route updates for new dashboard list endpoint

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b747311d508327a8d4b2e697a85308