### PR TITLE
Add vendor plan management with upgrade modal

### DIFF
--- a/app/Http/Controllers/Vendor/PlanController.php
+++ b/app/Http/Controllers/Vendor/PlanController.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use App\Models\Plan;
+use App\Models\UserPlan;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class PlanController extends Controller
+{
+    /**
+     * Show the current plan and available upgrades.
+     */
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        $currentPlan = UserPlan::with('plan')
+            ->where('user_id', $user->id)
+            ->where('status', 1)
+            ->orderByDesc('start_date')
+            ->first();
+
+        $plansQuery = Plan::orderBy('usd_price');
+        if ($currentPlan) {
+            $plansQuery->where('id', '!=', $currentPlan->plan_id);
+        }
+        $plans = $plansQuery->get();
+
+        return view('vendor.plan.index', compact('currentPlan', 'plans'));
+    }
+
+    /**
+     * Upgrade the authenticated user's plan.
+     */
+    public function update(Request $request)
+    {
+        $data = $request->validate([
+            'plan_id' => ['required', 'exists:plans,id'],
+        ]);
+
+        $plan = Plan::findOrFail($data['plan_id']);
+        $user = $request->user();
+
+        $start = Carbon::today();
+        $end = null;
+        if ($plan->billing_cycle === 'month') {
+            $end = $start->copy()->addMonth();
+        } elseif ($plan->billing_cycle === 'year') {
+            $end = $start->copy()->addYear();
+        }
+
+        DB::transaction(function () use ($user, $plan, $start, $end) {
+            UserPlan::where('user_id', $user->id)
+                ->where('status', 1)
+                ->update(['status' => 2]);
+
+            UserPlan::create([
+                'user_id'    => $user->id,
+                'plan_id'    => $plan->id,
+                'start_date' => $start->toDateString(),
+                'end_date'   => $end?->toDateString(),
+                'status'     => 1,
+            ]);
+        });
+
+        return response()->json(['success' => true]);
+    }
+}

--- a/resources/views/vendor/layouts/partials/sidebar.blade.php
+++ b/resources/views/vendor/layouts/partials/sidebar.blade.php
@@ -23,7 +23,7 @@
     <a class="nav-link " href="{{ route('vendor.analytics.index') }}">
       <i class="bi bi-bar-chart"></i> <span>Analytics</span>
     </a>
-    <a class="nav-link " href="">
+    <a class="nav-link " href="{{ route('vendor.plan.index') }}">
       <i class="bi bi-gem"></i> <span>Plan</span>
     </a>
 

--- a/resources/views/vendor/plan/index.blade.php
+++ b/resources/views/vendor/plan/index.blade.php
@@ -1,0 +1,109 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'Plan')
+
+@push('styles')
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{--bg:#f6f7fb;--surface:#fff;--text:#0f172a;--muted:#64748b;--line:#eaecef;}
+  .top-band{background:radial-gradient(1200px 220px at 50% -140px,rgba(59,130,246,.18)0%,rgba(59,130,246,0)60%),linear-gradient(180deg,#f6f7fb0%,#f6f7fb60%,transparent100%);border-bottom:1px solid var(--line);}
+  .crumb{display:flex;align-items:center;gap:.5rem;color:var(--muted);}
+  .crumb a{color:var(--text);text-decoration:none;}
+  .crumb i{opacity:.6;}
+</style>
+@endpush
+
+@section('content')
+  <div class="top-band">
+    <div class="container py-3">
+      <nav class="crumb">
+        <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <i class="bi bi-chevron-right"></i>
+        <span>Plan</span>
+      </nav>
+    </div>
+  </div>
+
+  <div class="container py-4">
+    <div class="card shadow-sm">
+      <div class="card-body">
+        @if($currentPlan)
+          <p>Your current plan: <strong>{{ $currentPlan->plan->name }}</strong></p>
+          <p>Price: ${{ $currentPlan->plan->usd_price }} / {{ $currentPlan->plan->billing_cycle }}</p>
+          @if($currentPlan->end_date)
+            <p>Expires on: {{ $currentPlan->end_date }}</p>
+          @endif
+        @else
+          <p>You are currently on the <strong>Free</strong> plan.</p>
+        @endif
+        <button class="btn btn-primary mt-3" data-bs-toggle="modal" data-bs-target="#upgradeModal">
+          <i class="bi bi-arrow-up-circle me-1"></i> Upgrade Plan
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="upgradeModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <form id="planForm" class="modal-content">
+        <div class="modal-header bg-primary text-white">
+          <h5 class="modal-title"><i class="bi bi-box-seam me-2"></i> Upgrade Your Plan</h5>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p class="text-muted mb-3">
+            <i class="bi bi-lightning-charge-fill text-warning me-1"></i>
+            Choose a plan that suits your needs.
+          </p>
+          <div class="mb-3">
+            <label for="planSelect" class="form-label fw-bold">
+              <i class="bi bi-gem text-info me-1"></i> Available Plans
+            </label>
+            <select class="form-select" id="planSelect" name="plan_id" required>
+              <option value="">-- Select a plan --</option>
+              @foreach($plans as $plan)
+                <option value="{{ $plan->id }}">{{ $plan->name }} - ${{ $plan->usd_price }} / {{ $plan->billing_cycle }}</option>
+              @endforeach
+            </select>
+          </div>
+        </div>
+        <div class="modal-footer bg-light">
+          <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">
+            <i class="bi bi-x-circle me-1"></i> Cancel
+          </button>
+          <button type="submit" id="btnPlanSave" class="btn btn-primary">
+            <i class="bi bi-check-circle me-1"></i> Save & Upgrade
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+@endsection
+
+@push('scripts')
+<script>
+  document.getElementById('planForm').addEventListener('submit', async function(e) {
+    e.preventDefault();
+    const btn = document.getElementById('btnPlanSave');
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Saving...';
+
+    const res = await fetch('{{ route('vendor.plan.update') }}', {
+      method: 'POST',
+      headers: {
+        'X-CSRF-TOKEN': '{{ csrf_token() }}',
+        'Accept': 'application/json'
+      },
+      body: new FormData(this)
+    });
+
+    if (res.ok) {
+      location.reload();
+    } else {
+      alert('Failed to update plan');
+      btn.disabled = false;
+      btn.innerHTML = '<i class="bi bi-check-circle me-1"></i> Save & Upgrade';
+    }
+  });
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -12,6 +12,7 @@ use App\Http\Controllers\ContactController;
 use App\Http\Controllers\PartnershipsController;
 use App\Http\Controllers\Vendor\DocumentController; // files + public viewer
 use App\Http\Controllers\Vendor\AnalyticsController;
+use App\Http\Controllers\Vendor\PlanController;
 
 /* ------------------------- Guest (auth) ------------------------- */
 Route::middleware('guest')->group(function () {
@@ -61,6 +62,8 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::post('files/generate-link', [DocumentController::class, 'generateLink'])->name('vendor.files.generate');
 
     Route::get('analytics',            [AnalyticsController::class, 'index'])->name('vendor.analytics.index');
+    Route::get('plan',                 [PlanController::class, 'index'])->name('vendor.plan.index');
+    Route::post('plan/update',         [PlanController::class, 'update'])->name('vendor.plan.update');
 });
 
 /* ------------------------- Public viewer (no auth) ------------------------- */


### PR DESCRIPTION
## Summary
- add PlanController to show current plan and handle plan upgrades
- create vendor plan view and modal for selecting a new plan
- wire up vendor routes and sidebar link for plan management

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b75b52acfc8327a55e2d85a7ed1868