### PR TITLE
Add file detail view with rename and link generation

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -74,6 +74,36 @@ class DocumentController extends Controller
         ]);
     }
 
+    public function show($id)
+    {
+        $doc = Document::where('id', $id)
+            ->where('user_id', Auth::id())
+            ->with('link')
+            ->firstOrFail();
+
+        $url = $doc->link ? URL::to('/view').'?doc='.$doc->link->slug : null;
+
+        return view('vendor.files.show', [
+            'doc' => $doc,
+            'url' => $url,
+        ]);
+    }
+
+    public function update(Request $request, $id)
+    {
+        $request->validate(['filename' => 'required|string|max:255']);
+
+        $doc = Document::where('id', $id)
+            ->where('user_id', Auth::id())
+            ->firstOrFail();
+
+        $safe = preg_replace('/[^A-Za-z0-9.\-_]/', '_', $request->input('filename'));
+        $doc->filename = $safe;
+        $doc->save();
+
+        return redirect()->back()->with('status', 'Filename updated');
+    }
+
     public function upload(Request $request)
     {
         $request->validate([

--- a/resources/views/vendor/files/manage.blade.php
+++ b/resources/views/vendor/files/manage.blade.php
@@ -140,6 +140,7 @@
     list: @json(route('vendor.files.manage.list')),
     generate: @json(route('vendor.files.generate')),
     delete: @json(route('vendor.files.delete')),
+    detailBase: @json(url('vendor/files/manage')),
   };
 
   let page = 1, q = '';
@@ -158,10 +159,10 @@
   function toast(msg){ const n=document.createElement('div'); n.textContent=msg; Object.assign(n.style,{position:'fixed',right:'16px',bottom:'16px',background:'#111',color:'#fff',padding:'10px 14px',borderRadius:'10px',zIndex:1060}); document.body.appendChild(n); setTimeout(()=>n.remove(),1600); }
 
   function rowTemplate(f){
-    const id=f.id||''; const filename=f.filename||'—'; const size=humanSize(f.size); const modified=f.modified||''; const timePart=f.time||''; const status=f.status||'Secure'; const url=f.public_url||'';
+    const id=f.id||''; const filename=f.filename||'—'; const size=humanSize(f.size); const modified=f.modified||''; const timePart=f.time||''; const status=f.status||'Secure'; const url=f.public_url||''; const detail=routes.detailBase+'/'+id;
     return `<tr data-id="${id}">
       <td><input class="form-check-input row-check" type="checkbox"/></td>
-      <td><div class="col-file"><span class="file-chip"><i class="bi ${iconByExt(filename)}"></i></span><div class="file-name"><a href="${url||'#'}" target="_blank">${escapeHtml(filename)}</a></div></div></td>
+      <td><div class="col-file"><span class="file-chip"><i class="bi ${iconByExt(filename)}"></i></span><div class="file-name"><a href="${detail}">${escapeHtml(filename)}</a></div></div></td>
       <td>${size}</td>
       <td><div>${escapeHtml(modified)}</div><small class="text-muted">${escapeHtml(timePart)}</small></td>
       <td><span class="status-pill">${escapeHtml(status)}</span></td>

--- a/resources/views/vendor/files/show.blade.php
+++ b/resources/views/vendor/files/show.blade.php
@@ -1,0 +1,55 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'File Details')
+
+@section('content')
+<div class="container py-3">
+  <div class="mb-3"><a href="{{ route('vendor.files.manage') }}" class="text-decoration-none"><i class="bi bi-arrow-left"></i> Back to files</a></div>
+  <div class="card p-4">
+    @if(session('status'))
+      <div class="alert alert-success">{{ session('status') }}</div>
+    @endif
+    <h2 class="mb-3">File Details</h2>
+    <form method="POST" action="{{ route('vendor.files.update', $doc->id) }}" class="d-flex flex-column flex-sm-row gap-2 mb-4">
+      @csrf
+      @method('PUT')
+      <input type="text" name="filename" value="{{ $doc->filename }}" class="form-control" />
+      <button class="btn btn-primary">Save</button>
+    </form>
+    <p><strong>Size:</strong> {{ number_format($doc->size / 1024, 2) }} KB</p>
+    <p><strong>Type:</strong> PDF</p>
+    <div class="my-3">
+      <button id="btnGenerate" type="button" class="btn btn-secondary">Generate Link</button>
+    </div>
+    <div class="input-group mb-3">
+      <input id="linkInput" type="text" class="form-control" value="{{ $url }}" readonly />
+      <button id="btnCopy" class="btn btn-outline-secondary" type="button">Copy</button>
+    </div>
+  </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+  document.getElementById('btnGenerate').addEventListener('click', function(){
+    fetch(@json(route('vendor.files.generate')), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-TOKEN': @json(csrf_token())
+      },
+      body: JSON.stringify({id: {{ $doc->id }}})
+    }).then(r => r.json()).then(data => {
+      if(data.url){
+        document.getElementById('linkInput').value = data.url;
+      }
+    });
+  });
+
+  document.getElementById('btnCopy').addEventListener('click', function(){
+    const input = document.getElementById('linkInput');
+    input.select();
+    document.execCommand('copy');
+  });
+</script>
+@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -58,6 +58,8 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::get('files/list',           [DocumentController::class, 'list'])->name('vendor.files.list');
     Route::get('files/manage',         [DocumentController::class, 'manage'])->name('vendor.files.manage');
     Route::get('files/manage/list',    [DocumentController::class, 'manageList'])->name('vendor.files.manage.list');
+    Route::get('files/manage/{id}',    [DocumentController::class, 'show'])->name('vendor.files.show');
+    Route::put('files/manage/{id}',    [DocumentController::class, 'update'])->name('vendor.files.update');
     Route::post('files/upload',        [DocumentController::class, 'upload'])->name('vendor.files.upload');
     Route::post('files/delete',        [DocumentController::class, 'destroy'])->name('vendor.files.delete');
     Route::post('files/generate-link', [DocumentController::class, 'generateLink'])->name('vendor.files.generate');


### PR DESCRIPTION
## Summary
- Add routes and controller actions to show individual file details and rename files
- Create file detail blade view with link generator and copy button
- Link file names in manage table to detail page

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b767a60f548327b89b20de274dc3dc