### PR TITLE
Highlight active sidebar menu items

### DIFF
--- a/resources/views/vendor/layouts/partials/sidebar.blade.php
+++ b/resources/views/vendor/layouts/partials/sidebar.blade.php
@@ -11,37 +11,37 @@
 
   <!-- NEW MENU -->
   <nav class="nav flex-column gap-1" id="mainNav">
-    <a class="nav-link " href="{{ route('dashboard') }}">
+    <a class="nav-link {{ request()->routeIs('dashboard') ? 'active' : '' }}" href="{{ route('dashboard') }}">
       <i class="bi bi-speedometer2"></i> <span>Dashboard</span>
     </a>
-    <a class="nav-link " href="{{ route('vendor.files.index') }}">
+    <a class="nav-link {{ request()->routeIs('vendor.files.index') ? 'active' : '' }}" href="{{ route('vendor.files.index') }}">
       <i class="bi bi-cloud-arrow-up"></i> <span>Upload Files</span>
     </a>
-    <a class="nav-link " href="{{ route('vendor.files.manage') }}">
+    <a class="nav-link {{ request()->routeIs('vendor.files.manage') ? 'active' : '' }}" href="{{ route('vendor.files.manage') }}">
       <i class="bi bi-folder2-open"></i> <span>Manage Files</span>
     </a>
-    <a class="nav-link " href="{{ route('vendor.analytics.index') }}">
+    <a class="nav-link {{ request()->routeIs('vendor.analytics.index') ? 'active' : '' }}" href="{{ route('vendor.analytics.index') }}">
       <i class="bi bi-bar-chart"></i> <span>Analytics</span>
     </a>
-    <a class="nav-link " href="{{ route('vendor.plan.index') }}">
+    <a class="nav-link {{ request()->routeIs('vendor.plan.index') ? 'active' : '' }}" href="{{ route('vendor.plan.index') }}">
       <i class="bi bi-gem"></i> <span>Plan</span>
     </a>
 
     <!-- Settings collapsible -->
-    <a class="nav-link " data-bs-toggle="collapse" href="#settingsMenu" role="button" aria-expanded="false" aria-controls="settingsMenu">
+    <a class="nav-link {{ request()->routeIs('profile') || request()->routeIs('password.*') ? 'active' : '' }}" data-bs-toggle="collapse" href="#settingsMenu" role="button" aria-expanded="{{ request()->routeIs('profile') || request()->routeIs('password.*') ? 'true' : 'false' }}" aria-controls="settingsMenu">
       <i class="bi bi-gear"></i> <span>Settings</span>
       <span class="ms-auto"><i class="bi bi-caret-down-fill"></i></span>
     </a>
-    <div class="collapse subnav " id="settingsMenu" data-bs-parent="#mainNav">
-      <a class="nav-link " href="{{ route('profile') }}">
+    <div class="collapse subnav {{ request()->routeIs('profile') || request()->routeIs('password.*') ? 'show' : '' }}" id="settingsMenu" data-bs-parent="#mainNav">
+      <a class="nav-link {{ request()->routeIs('profile') ? 'active' : '' }}" href="{{ route('profile') }}">
         <i class="bi bi-person me-1"></i> <span>Profile</span>
       </a>
-      <a class="nav-link " href="{{ route('password.edit') }}">
+      <a class="nav-link {{ request()->routeIs('password.edit') ? 'active' : '' }}" href="{{ route('password.edit') }}">
         <i class="bi bi-key me-1"></i> <span>Change Password</span>
       </a>
     </div>
 
-    <a class="nav-link " href="{{ route('vendor.help.manage') }}">
+    <a class="nav-link {{ request()->routeIs('vendor.help.manage') ? 'active' : '' }}" href="{{ route('vendor.help.manage') }}">
       <i class="bi bi-life-preserver"></i> <span>Help</span>
     </a>
   </nav>


### PR DESCRIPTION
## Summary
- mark sidebar links active based on current route
- expand settings submenu when profile or password pages are open

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b76dab4d44832787ab4f6ea7d23b2f