### PR TITLE
Support image embedding on vendor embed page

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -210,6 +210,27 @@ class DocumentController extends Controller
         return response()->json(['url' => $url]);
     }
 
+    public function embed(Request $request)
+    {
+        $url = (string) $request->query('url', '');
+        $extension = strtolower(pathinfo(parse_url($url, PHP_URL_PATH) ?? '', PATHINFO_EXTENSION));
+        $imageTypes = ['jpg','jpeg','png','gif','webp','bmp','svg'];
+        $isImage = in_array($extension, $imageTypes, true);
+
+        $snippet = '';
+        if ($url) {
+            $snippet = $isImage
+                ? '<img src="'.$url.'" alt="" style="max-width:100%;height:auto;border-radius:8px;">'
+                : '<iframe src="'.$url.'" width="100%" height="600" style="border:none;border-radius:8px;"></iframe>';
+        }
+
+        return view('vendor.files.embed', [
+            'url' => $url,
+            'isImage' => $isImage,
+            'snippet' => $snippet,
+        ]);
+    }
+
     /**
      * Pretty viewer route: /view?doc=SLUG
      * Shows Blade viewer and (optionally) logs a "view" event.

--- a/core-php/vendor_dashboard/embed.php
+++ b/core-php/vendor_dashboard/embed.php
@@ -6,9 +6,17 @@ include 'includes/topbar.php';
 
 $url = $_GET['url'] ?? '';
 $safeUrl = htmlspecialchars($url, ENT_QUOTES);
+$extension = strtolower(pathinfo(parse_url($url, PHP_URL_PATH) ?? '', PATHINFO_EXTENSION));
+$imageTypes = ['jpg','jpeg','png','gif','webp','bmp','svg'];
+$isImage = in_array($extension, $imageTypes, true);
 $rawSnippet = $url
-  ? '<iframe src="' . $url . '" width="100%" height="600" style="border:none;border-radius:8px;"></iframe>'
+  ? ($isImage
+      ? '<img src="' . $url . '" alt="" style="max-width:100%;height:auto;border-radius:8px;">'
+      : '<iframe src="' . $url . '" width="100%" height="600" style="border:none;border-radius:8px;"></iframe>'
+    )
   : '';
+$titleText = $isImage ? 'Embed Image' : 'Embed PDF Viewer';
+$iconClass = $isImage ? 'bi-card-image text-info' : 'bi-file-earmark-pdf text-danger';
 ?>
 <style>
   /* Page header row */
@@ -37,8 +45,13 @@ $rawSnippet = $url
     width:100%; height:600px; border:1px solid #e5e7eb; border-radius:8px;
     background:#0b1220;
   }
+  .viewer-wrap img{
+    max-width:100%; border:1px solid #e5e7eb; border-radius:8px;
+    background:#0b1220;
+  }
   @media (max-width: 768px){
     .viewer-wrap iframe{ height:70vh; }
+    .viewer-wrap img{ max-height:70vh; }
   }
 
   /* Small helpers */
@@ -49,8 +62,8 @@ $rawSnippet = $url
   <!-- Top bar with title + actions -->
   <div class="d-sm-flex align-items-center justify-content-between mb-3 page-header">
     <h1 class="h3 mb-0 text-gray-800">
-      <i class="bi bi-file-earmark-pdf text-danger"></i>
-      <span>Embed PDF Viewer</span>
+      <i class="<?php echo $iconClass; ?>"></i>
+      <span><?php echo $titleText; ?></span>
     </h1>
 
     <?php if ($url): ?>
@@ -60,7 +73,7 @@ $rawSnippet = $url
           <i class="bi bi-box-arrow-up-right"></i><span>Open Link</span>
         </a>
         <button class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1"
-                id="copyUrlBtn" data-bs-toggle="tooltip" data-bs-title="Copy the PDF URL">
+                id="copyUrlBtn" data-bs-toggle="tooltip" data-bs-title="Copy the file URL">
           <i class="bi bi-link-45deg"></i><span>Copy URL</span>
         </button>
       </div>
@@ -78,7 +91,7 @@ $rawSnippet = $url
         <div class="code-card border rounded">
           <div class="code-toolbar">
             <button class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1"
-                    id="copyCodeBtn" data-bs-toggle="tooltip" data-bs-title="Copy the iframe embed code">
+                    id="copyCodeBtn" data-bs-toggle="tooltip" data-bs-title="Copy the embed code">
               <i class="bi bi-clipboard"></i><span>Copy</span>
             </button>
           </div>
@@ -91,9 +104,15 @@ $rawSnippet = $url
             <h6 class="mb-0 d-flex align-items-center gap-2">
               <i class="bi bi-display"></i><span>Live Preview</span>
             </h6>
-            <div class="muted-note small">Height auto-adjusts on mobile.</div>
+            <div class="muted-note small">
+              <?php echo $isImage ? 'Image scales to fit container.' : 'Height auto-adjusts on mobile.'; ?>
+            </div>
           </div>
-          <iframe src="<?php echo $safeUrl; ?>" allow="clipboard-write"></iframe>
+          <?php if ($isImage): ?>
+            <img src="<?php echo $safeUrl; ?>" alt="">
+          <?php else: ?>
+            <iframe src="<?php echo $safeUrl; ?>" allow="clipboard-write"></iframe>
+          <?php endif; ?>
         </div>
       <?php else: ?>
         <p class="mb-0">No URL provided.</p>

--- a/resources/views/vendor/files/embed.blade.php
+++ b/resources/views/vendor/files/embed.blade.php
@@ -1,0 +1,120 @@
+@extends('vendor.layouts.app')
+
+@php
+  $titleText = $isImage ? 'Embed Image' : 'Embed PDF Viewer';
+  $iconClass = $isImage ? 'bi-card-image text-info' : 'bi-file-earmark-pdf text-danger';
+@endphp
+
+@section('title', $titleText)
+
+@push('styles')
+<style>
+  /* Page header row */
+  .page-header { gap: 1rem; padding: .5rem 0; }
+  .page-header h1 { display:flex; align-items:center; gap:.5rem; }
+
+  /* Code block card */
+  .code-card { position:relative; overflow:hidden; }
+  .code-toolbar { display:flex; gap:.5rem; align-items:center; justify-content:flex-end; padding:.5rem .75rem; border-bottom:1px solid #e9ecef; background:#f8f9fa; }
+  pre { background:#0f172a; color:#e2e8f0; margin:0; padding:1rem 1.25rem; border-radius:0 0 .5rem .5rem; font-size:.9rem; overflow:auto; }
+  pre code { white-space:pre; }
+
+  /* Viewer */
+  .viewer-wrap iframe { width:100%; height:600px; border:1px solid #e5e7eb; border-radius:8px; background:#0b1220; }
+  .viewer-wrap img { max-width:100%; border:1px solid #e5e7eb; border-radius:8px; background:#0b1220; }
+  @media (max-width:768px){ .viewer-wrap iframe{ height:70vh; } .viewer-wrap img{ max-height:70vh; } }
+
+  /* Small helpers */
+  .muted-note { color:#64748b; }
+</style>
+@endpush
+
+@section('content')
+<div class="container-fluid">
+  <div class="d-sm-flex align-items-center justify-content-between mb-3 page-header">
+    <h1 class="h3 mb-0 text-gray-800">
+      <i class="{{ $iconClass }}"></i>
+      <span>{{ $titleText }}</span>
+    </h1>
+    @if($url)
+    <div class="d-flex align-items-center gap-2" style="gap:5px;">
+      <a href="{{ $url }}" target="_blank" rel="noopener" class="btn btn-sm btn-primary d-flex align-items-center gap-1">
+        <i class="bi bi-box-arrow-up-right"></i><span>Open Link</span>
+      </a>
+      <button class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1" id="copyUrlBtn" data-bs-toggle="tooltip" data-bs-title="Copy the file URL">
+        <i class="bi bi-link-45deg"></i><span>Copy URL</span>
+      </button>
+    </div>
+    @endif
+  </div>
+
+  <div class="card shadow-sm mb-4">
+    <div class="card-body">
+      @if($url)
+        <div class="mb-3 muted-note small">Use this snippet to embed your viewer anywhere.</div>
+        <div class="code-card border rounded">
+          <div class="code-toolbar">
+            <button class="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1" id="copyCodeBtn" data-bs-toggle="tooltip" data-bs-title="Copy the embed code">
+              <i class="bi bi-clipboard"></i><span>Copy</span>
+            </button>
+          </div>
+          <pre class="mb-0"><code id="embedCode">{{ $snippet }}</code></pre>
+        </div>
+        <div class="mt-4 viewer-wrap">
+          <div class="d-flex align-items-center justify-content-between mb-2">
+            <h6 class="mb-0 d-flex align-items-center gap-2">
+              <i class="bi bi-display"></i><span>Live Preview</span>
+            </h6>
+            <div class="muted-note small">{{ $isImage ? 'Image scales to fit container.' : 'Height auto-adjusts on mobile.' }}</div>
+          </div>
+          @if($isImage)
+            <img src="{{ $url }}" alt="">
+          @else
+            <iframe src="{{ $url }}" allow="clipboard-write"></iframe>
+          @endif
+        </div>
+      @else
+        <p class="mb-0">No URL provided.</p>
+      @endif
+    </div>
+  </div>
+</div>
+
+<!-- Toast for copy feedback -->
+<div class="position-fixed bottom-0 end-0 p-3" style="z-index:1055">
+  <div id="copyToast" class="toast align-items-center text-bg-dark border-0" role="status" aria-live="polite" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body" id="toastMsg">Copied!</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+</div>
+@endsection
+
+@push('scripts')
+<script>
+(function(){
+  const copyText = async (text) => {
+    try { await navigator.clipboard.writeText(text); showToast('Copied to clipboard'); }
+    catch(e){ showToast('Copy failed'); }
+  };
+
+  const showToast = (msg) => {
+    const el=document.getElementById('copyToast');
+    const msgEl=document.getElementById('toastMsg');
+    if(!el||!msgEl) return;
+    msgEl.textContent=msg;
+    const t=bootstrap.Toast.getOrCreateInstance(el,{delay:1600});
+    t.show();
+  };
+
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el=>{ new bootstrap.Tooltip(el); });
+
+  const copyCodeBtn=document.getElementById('copyCodeBtn');
+  const copyUrlBtn=document.getElementById('copyUrlBtn');
+
+  if(copyCodeBtn){ copyCodeBtn.addEventListener('click',()=>{ const code=document.getElementById('embedCode').innerText; copyText(code); }); }
+  if(copyUrlBtn){ copyUrlBtn.addEventListener('click',()=>{ copyText(@json($url)); }); }
+})();
+</script>
+@endpush

--- a/resources/views/vendor/files/manage.blade.php
+++ b/resources/views/vendor/files/manage.blade.php
@@ -141,6 +141,7 @@
     generate: @json(route('vendor.files.generate')),
     delete: @json(route('vendor.files.delete')),
     detailBase: @json(url('vendor/files/manage')),
+    embed: @json(route('vendor.files.embed')),
   };
 
   let page = 1, q = '';
@@ -262,8 +263,7 @@
     }
     if(e.target.closest('.btn-embed')){
       const link=tr.querySelector('.small-link a')?.href; if(!link){ toast('Generate first'); return; }
-      const code=`<iframe src="${link}" width="100%" height="600" frameborder="0"></iframe>`;
-      await navigator.clipboard.writeText(code); toast('Embed code copied');
+      window.open(routes.embed+'?url='+encodeURIComponent(link),'_blank');
       return;
     }
     if(e.target.closest('.btn-delete')){

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,6 +63,7 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::post('files/upload',        [DocumentController::class, 'upload'])->name('vendor.files.upload');
     Route::post('files/delete',        [DocumentController::class, 'destroy'])->name('vendor.files.delete');
     Route::post('files/generate-link', [DocumentController::class, 'generateLink'])->name('vendor.files.generate');
+    Route::get('files/embed',          [DocumentController::class, 'embed'])->name('vendor.files.embed');
 
     Route::get('analytics',            [AnalyticsController::class, 'index'])->name('vendor.analytics.index');
     Route::get('plan',                 [PlanController::class, 'index'])->name('vendor.plan.index');


### PR DESCRIPTION
## Summary
- Add controller and route for dedicated embed page supporting images and PDFs
- Create new Blade view with code snippet and live preview
- Link Manage Files embed action to new page

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b7cb704b50832790b0123bc10bf2b5