### PR TITLE
Display generated links on vendor file management page

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -58,12 +58,13 @@ class DocumentController extends Controller
             $query->where('filename', 'like', "%{$search}%");
         }
 
-        $docs = $query->latest()->paginate(10);
+        $docs = $query->with('link')->latest()->paginate(10);
         $files = $docs->getCollection()->map(fn($d) => [
-            'id'       => $d->id,
-            'filename' => $d->filename,
-            'size'     => (int) $d->size,
-            'modified' => optional($d->updated_at)->format('Y-m-d H:i'),
+            'id'         => $d->id,
+            'filename'   => $d->filename,
+            'size'       => (int) $d->size,
+            'modified'   => optional($d->updated_at)->format('Y-m-d H:i'),
+            'public_url' => $d->link ? URL::to('/view').'?doc='.$d->link->slug : null,
         ]);
 
         return response()->json([


### PR DESCRIPTION
## Summary
- include each document's public URL in manage list so generated links persist

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b7d041bc3c8327a30412816d3bf92f