### PR TITLE
Enable AJAX contact form submission

### DIFF
--- a/resources/views/partnerships.blade.php
+++ b/resources/views/partnerships.blade.php
@@ -164,7 +164,7 @@
 
     setLoading(true);
     try{
-      const res = await fetch(@json(route('partnerships.store')), {
+      const res = await fetch(form.action, {
         method:'POST',
         headers: {
           'X-Requested-With': 'XMLHttpRequest',


### PR DESCRIPTION
## Summary
- wire contact form to `contact.store` and enable AJAX submission with CSRF protection
- reuse `form.action` in partnerships form for cleaner request handling

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b8193a70308327aaef646156e86e78