### PR TITLE
Use floating labels on contact and partnership forms

### DIFF
--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -32,36 +32,35 @@
               @csrf
               <div class="row">
                 <div class="col-md-6">
-                  <div class="mb-3">
-                    <label for="firstName" class="form-label">First Name</label>
-                    <input type="text" class="form-control" id="firstName" name="firstName" value="{{ old('firstName') }}">
-                    <div id="firstName_error" class="error-message">@error('firstName'){{ $message }}@enderror</div>
+                  <div class="form-floating mb-1">
+                    <input type="text" class="form-control @error('firstName') is-invalid @enderror" id="firstName" name="firstName" placeholder="First Name" value="{{ old('firstName') }}">
+                    <label for="firstName">First Name</label>
                   </div>
+                  <div id="firstName_error" class="error-message">@error('firstName'){{ $message }}@enderror</div>
                 </div>
                 <div class="col-md-6">
-                  <div class="mb-3">
-                    <label for="lastName" class="form-label">Last Name</label>
-                    <input type="text" class="form-control" id="lastName" name="lastName" value="{{ old('lastName') }}">
-                    <div id="lastName_error" class="error-message">@error('lastName'){{ $message }}@enderror</div>
+                  <div class="form-floating mb-1">
+                    <input type="text" class="form-control @error('lastName') is-invalid @enderror" id="lastName" name="lastName" placeholder="Last Name" value="{{ old('lastName') }}">
+                    <label for="lastName">Last Name</label>
                   </div>
+                  <div id="lastName_error" class="error-message">@error('lastName'){{ $message }}@enderror</div>
                 </div>
               </div>
 
-              <div class="mb-3">
-                <label for="email" class="form-label">Email Address</label>
-                <input type="email" class="form-control" id="email" name="email" value="{{ old('email') }}">
-                <div id="email_error" class="error-message">@error('email'){{ $message }}@enderror</div>
+              <div class="form-floating mb-1">
+                <input type="email" class="form-control @error('email') is-invalid @enderror" id="email" name="email" placeholder="Email Address" value="{{ old('email') }}">
+                <label for="email">Email Address</label>
               </div>
+              <div id="email_error" class="error-message">@error('email'){{ $message }}@enderror</div>
 
-              <div class="mb-3">
-                <label for="company" class="form-label">Company (Optional)</label>
-                <input type="text" class="form-control" id="company" name="company" value="{{ old('company') }}">
-                <div id="company_error" class="error-message">@error('company'){{ $message }}@enderror</div>
+              <div class="form-floating mb-1">
+                <input type="text" class="form-control @error('company') is-invalid @enderror" id="company" name="company" placeholder="Company (Optional)" value="{{ old('company') }}">
+                <label for="company">Company (Optional)</label>
               </div>
+              <div id="company_error" class="error-message">@error('company'){{ $message }}@enderror</div>
 
-              <div class="mb-3">
-                <label for="subject" class="form-label">Subject</label>
-                <select class="form-select" id="subject" name="subject">
+              <div class="form-floating mb-1">
+                <select class="form-select @error('subject') is-invalid @enderror" id="subject" name="subject">
                   <option value="" @selected(old('subject')==='') disabled>Select a subject</option>
                   <option value="sales" @selected(old('subject')==='sales')>Sales Inquiry</option>
                   <option value="support" @selected(old('subject')==='support')>Technical Support</option>
@@ -69,14 +68,15 @@
                   <option value="partnership" @selected(old('subject')==='partnership')>Partnership Opportunity</option>
                   <option value="other" @selected(old('subject')==='other')>Other</option>
                 </select>
-                <div id="subject_error" class="error-message">@error('subject'){{ $message }}@enderror</div>
+                <label for="subject">Subject</label>
               </div>
+              <div id="subject_error" class="error-message">@error('subject'){{ $message }}@enderror</div>
 
-              <div class="mb-4">
-                <label for="message" class="form-label">Message</label>
-                <textarea class="form-control" id="message" name="message" rows="5">{{ old('message') }}</textarea>
-                <div id="message_error" class="error-message">@error('message'){{ $message }}@enderror</div>
+              <div class="form-floating mb-1">
+                <textarea class="form-control @error('message') is-invalid @enderror" id="message" name="message" placeholder="Message" style="height: 150px">{{ old('message') }}</textarea>
+                <label for="message">Message</label>
               </div>
+              <div id="message_error" class="error-message mb-4">@error('message'){{ $message }}@enderror</div>
 
               <button type="submit" class="btn btn-brand btn-lg w-100">Send Message</button>
               <div id="form_success" class="mt-3 form-success" @if(!session('contact_success'))style="display:none;"@endif>

--- a/resources/views/partnerships.blade.php
+++ b/resources/views/partnerships.blade.php
@@ -31,47 +31,47 @@
             @csrf
             <div class="row">
               <div class="col-md-6">
-                <div class="mb-3">
-                  <label for="firstName" class="form-label">First Name</label>
+                <div class="form-floating mb-1">
                   <input type="text" class="form-control @error('firstName') is-invalid @enderror"
-                         id="firstName" name="firstName" autocomplete="given-name" maxlength="100"
+                         id="firstName" name="firstName" autocomplete="given-name" maxlength="100" placeholder="First Name"
                          value="{{ old('firstName') }}">
-                  <div id="firstName_error" class="error-message">@error('firstName'){{ $message }}@enderror</div>
+                  <label for="firstName">First Name</label>
                 </div>
+                <div id="firstName_error" class="error-message">@error('firstName'){{ $message }}@enderror</div>
               </div>
               <div class="col-md-6">
-                <div class="mb-3">
-                  <label for="lastName" class="form-label">Last Name</label>
+                <div class="form-floating mb-1">
                   <input type="text" class="form-control @error('lastName') is-invalid @enderror"
-                         id="lastName" name="lastName" autocomplete="family-name" maxlength="100"
+                         id="lastName" name="lastName" autocomplete="family-name" maxlength="100" placeholder="Last Name"
                          value="{{ old('lastName') }}">
-                  <div id="lastName_error" class="error-message">@error('lastName'){{ $message }}@enderror</div>
+                  <label for="lastName">Last Name</label>
                 </div>
+                <div id="lastName_error" class="error-message">@error('lastName'){{ $message }}@enderror</div>
               </div>
             </div>
 
-            <div class="mb-3">
-              <label for="email" class="form-label">Email Address</label>
+            <div class="form-floating mb-1">
               <input type="email" class="form-control @error('email') is-invalid @enderror"
-                     id="email" name="email" autocomplete="email" maxlength="150"
+                     id="email" name="email" autocomplete="email" maxlength="150" placeholder="Email Address"
                      value="{{ old('email') }}">
-              <div id="email_error" class="error-message">@error('email'){{ $message }}@enderror</div>
+              <label for="email">Email Address</label>
             </div>
+            <div id="email_error" class="error-message">@error('email'){{ $message }}@enderror</div>
 
-            <div class="mb-3">
-              <label for="contact_number" class="form-label">Contact Number</label>
+            <div class="form-floating mb-1">
               <input type="text" class="form-control @error('contact_number') is-invalid @enderror"
-                     id="contact_number" name="contact_number" autocomplete="tel" maxlength="32" inputmode="tel"
+                     id="contact_number" name="contact_number" autocomplete="tel" maxlength="32" inputmode="tel" placeholder="Contact Number"
                      value="{{ old('contact_number') }}">
-              <div id="contact_number_error" class="error-message">@error('contact_number'){{ $message }}@enderror</div>
+              <label for="contact_number">Contact Number</label>
             </div>
+            <div id="contact_number_error" class="error-message">@error('contact_number'){{ $message }}@enderror</div>
 
-            <div class="mb-4">
-              <label for="message" class="form-label">Message</label>
+            <div class="form-floating mb-1">
               <textarea class="form-control @error('message') is-invalid @enderror"
-                        id="message" name="message" rows="5" maxlength="10000">{{ old('message') }}</textarea>
-              <div id="message_error" class="error-message">@error('message'){{ $message }}@enderror</div>
+                        id="message" name="message" maxlength="10000" placeholder="Message" style="height: 150px">{{ old('message') }}</textarea>
+              <label for="message">Message</label>
             </div>
+            <div id="message_error" class="error-message mb-4">@error('message'){{ $message }}@enderror</div>
 
             <button type="submit" class="btn btn-brand btn-lg w-100">Send Inquiry</button>
             <div id="form_success" class="mt-3 form-success"


### PR DESCRIPTION
## Summary
- Switch contact form inputs to Bootstrap floating labels
- Use floating label style for partnership inquiry form

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b81ae6bdc48327bcacb293a3c39fa1