### PR TITLE
Add captcha to partnerships form

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -55,7 +55,14 @@ class HomeController extends Controller
 
     public function partnerships()
     {
-        return view('partnerships');
+        $a = random_int(1, 9);
+        $b = random_int(1, 9);
+        session(['captcha_answer' => $a + $b]);
+
+        return view('partnerships', [
+            'captcha_a' => $a,
+            'captcha_b' => $b,
+        ]);
     }
 
     

--- a/app/Http/Controllers/PartnershipsController.php
+++ b/app/Http/Controllers/PartnershipsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Models\PartnershipMessage;
+use App\Rules\Captcha;
 
 class PartnershipsController extends Controller
 {
@@ -16,6 +17,7 @@ class PartnershipsController extends Controller
             'email'           => ['required','email','max:150'],
             'contact_number'  => ['required','string','max:32'],
             'message'         => ['required','string','min:5','max:10000'],
+            'captcha'         => ['required', new Captcha()],
         ], [], [
             'firstName' => 'first name',
             'lastName'  => 'last name',
@@ -29,7 +31,14 @@ class PartnershipsController extends Controller
             'contact_number' => $data['contact_number'],
             'message'        => $data['message'],
         ]);
+        $a = random_int(1, 9);
+        $b = random_int(1, 9);
+        session(['captcha_answer' => $a + $b]);
 
-        return response()->json(['success' => true]);
+        return response()->json([
+            'success'    => true,
+            'captcha_a'  => $a,
+            'captcha_b'  => $b,
+        ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,7 @@ Route::post('/subscribe', [NewsletterSubscriptionController::class, 'store'])->n
 /* Contact + Partnerships (AJAX) */
 Route::post('/contact', [ContactController::class, 'store'])->name('contact.store');
 Route::post('/contact/captcha', [ContactController::class, 'refreshCaptcha'])->name('contact.captcha');
+Route::post('/partnerships/captcha', [ContactController::class, 'refreshCaptcha'])->name('partnerships.captcha');
 Route::post('/partnerships', [PartnershipsController::class, 'store'])->name('partnerships.store');
 
 /* ------------------------- Vendor dashboard ------------------------- */


### PR DESCRIPTION
## Summary
- add math-based captcha setup to partnerships page
- validate and refresh captcha in partnerships submissions
- expose `/partnerships/captcha` endpoint for refresh requests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b8207214208327945cbb0b579569f5