### PR TITLE
Add captcha to registration form

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Rules\Captcha;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
@@ -14,7 +15,14 @@ class RegisterController extends Controller
 {
     public function create()
     {
-        return view('auth.register');
+        $a = random_int(1, 9);
+        $b = random_int(1, 9);
+        session(['captcha_answer' => $a + $b]);
+
+        return view('auth.register', [
+            'captcha_a' => $a,
+            'captcha_b' => $b,
+        ]);
     }
 
     public function store(Request $request)
@@ -29,6 +37,7 @@ class RegisterController extends Controller
             'email'        => ['required','email','max:255','unique:users,email'],
             'password'     => ['required','string','min:6'],
             'agreed_terms' => ['accepted'], // checkbox must be checked
+            'captcha'      => ['required', new Captcha()],
         ], [
             'agreed_terms.accepted' => 'Terms must be accepted',
         ]);
@@ -72,7 +81,16 @@ class RegisterController extends Controller
             ]);
 
             DB::commit();
-            return response()->json(['success' => true]);
+
+            $a = random_int(1, 9);
+            $b = random_int(1, 9);
+            session(['captcha_answer' => $a + $b]);
+
+            return response()->json([
+                'success'   => true,
+                'captcha_a' => $a,
+                'captcha_b' => $b,
+            ]);
         } catch (\Illuminate\Validation\ValidationException $ve) {
             DB::rollBack();
             throw $ve;

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Vendor\HelpRequestController;
 Route::middleware('guest')->group(function () {
     Route::get('/register', [RegisterController::class, 'create'])->name('register');
     Route::post('/register', [RegisterController::class, 'store'])->name('register.store');
+    Route::post('/register/captcha', [ContactController::class, 'refreshCaptcha'])->name('register.captcha');
 
     Route::get('/login', [LoginController::class, 'create'])->name('login');
     Route::post('/login', [LoginController::class, 'store'])->name('login.store');


### PR DESCRIPTION
## Summary
- integrate math captcha into registration view
- validate captcha during registration and add refresh route
- expose captcha refresh endpoint for guest registration page

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b821ba61f08327a6c7465240443000