### PR TITLE
Fix 419 error for captcha refresh

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Login</title>
-  <meta name="csrf-token" content="dqiXSHcP7rwGlEqKXIvz82w3pAIt7OEs7OQScHqU">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
 
   <!-- Fonts & Vendors -->
   <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -12,7 +12,7 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
-  <meta name="csrf-token" content="nlvhZBZnGZLoNkwuSraacLRdqWjYa1tHPCusv9d3">
+  <meta name="csrf-token" content="{{ csrf_token() }}">
 
   <!-- Page CSS (Monochrome, black background) -->
   <style>
@@ -281,7 +281,7 @@
     if (refreshBtn) {
       refreshBtn.addEventListener('click', async function(){
         try {
-          const res = await fetch('http://localhost/onepdf-app-laravel/public/register/captcha', {
+          const res = await fetch(@json(route('register.captcha')), {
             method:'POST',
             headers:{ 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content') }
           });


### PR DESCRIPTION
## Summary
- replace hard-coded CSRF tokens with dynamic tokens in login and registration views
- use route helper for captcha refresh request to avoid expired token errors

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b8236da0cc832787ef4c4fb06991b5