### PR TITLE
Add missing favicon links to standalone views

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -6,6 +6,13 @@
   <title>Login</title>
   <meta name="csrf-token" content="{{ csrf_token() }}">
 
+  {{-- Favicons --}}
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('assets/favicon_io/apple-touch-icon.png') }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('assets/favicon_io/favicon-32x32.png') }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('assets/favicon_io/favicon-16x16.png') }}">
+  <link rel="manifest" href="{{ asset('assets/favicon_io/site.webmanifest') }}">
+  <link rel="shortcut icon" href="{{ asset('assets/favicon_io/favicon.ico') }}">
+
   <!-- Fonts & Vendors -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>Registration</title>
 
+  {{-- Favicons --}}
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('assets/favicon_io/apple-touch-icon.png') }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('assets/favicon_io/favicon-32x32.png') }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('assets/favicon_io/favicon-16x16.png') }}">
+  <link rel="manifest" href="{{ asset('assets/favicon_io/site.webmanifest') }}">
+  <link rel="shortcut icon" href="{{ asset('assets/favicon_io/favicon.ico') }}">
+
   <!-- Fonts & Vendors -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/resources/views/public/view.blade.php
+++ b/resources/views/public/view.blade.php
@@ -11,6 +11,12 @@
 <meta name="viewport" content="width=device-width,initial-scale=1" />
 <title>PDF Viewer</title>
 
+<link rel="apple-touch-icon" sizes="180x180" href="{{ asset('assets/favicon_io/apple-touch-icon.png') }}">
+<link rel="icon" type="image/png" sizes="32x32" href="{{ asset('assets/favicon_io/favicon-32x32.png') }}">
+<link rel="icon" type="image/png" sizes="16x16" href="{{ asset('assets/favicon_io/favicon-16x16.png') }}">
+<link rel="manifest" href="{{ asset('assets/favicon_io/site.webmanifest') }}">
+<link rel="shortcut icon" href="{{ asset('assets/favicon_io/favicon.ico') }}">
+
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css">

--- a/resources/views/vendor/layouts/app.blade.php
+++ b/resources/views/vendor/layouts/app.blade.php
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>@yield('title', 'Subcom Dashboard')</title>
 
+  {{-- Favicons --}}
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('assets/favicon_io/apple-touch-icon.png') }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('assets/favicon_io/favicon-32x32.png') }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('assets/favicon_io/favicon-16x16.png') }}">
+  <link rel="manifest" href="{{ asset('assets/favicon_io/site.webmanifest') }}">
+  <link rel="shortcut icon" href="{{ asset('assets/favicon_io/favicon.ico') }}">
+
   <!-- DM Sans + Bootstrap + Icons -->
   <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,6 +6,13 @@
 
         <title>{{ config('app.name', 'Laravel') }}</title>
 
+        <!-- Favicons -->
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('assets/favicon_io/apple-touch-icon.png') }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('assets/favicon_io/favicon-32x32.png') }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('assets/favicon_io/favicon-16x16.png') }}">
+        <link rel="manifest" href="{{ asset('assets/favicon_io/site.webmanifest') }}">
+        <link rel="shortcut icon" href="{{ asset('assets/favicon_io/favicon.ico') }}">
+
         <!-- Fonts -->
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=instrument-sans:400,500,600" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- include favicon tags in login and registration views
- embed favicons in public PDF viewer and vendor dashboard layout
- add favicon references to the Laravel welcome page

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b824c9d83c832788db298facd50c78