### PR TITLE
Add country dropdown with seeder for registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Models\User;
+use App\Models\Country;
 use App\Rules\Captcha;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -19,9 +20,12 @@ class RegisterController extends Controller
         $b = random_int(1, 9);
         session(['captcha_answer' => $a + $b]);
 
+        $countries = Country::orderBy('name')->get();
+
         return view('auth.register', [
             'captcha_a' => $a,
             'captcha_b' => $b,
+            'countries' => $countries,
         ]);
     }
 
@@ -31,7 +35,7 @@ class RegisterController extends Controller
         $validated = $request->validate([
             'first_name'   => ['required','string','max:255'],
             'last_name'    => ['required','string','max:255'],
-            'country'      => ['required','string','max:255'],
+            'country'      => ['required','string','max:255','exists:countries,name'],
             'company'      => ['required','string','max:255'],
             'plan_id'      => ['required','in:1,2,3,4,5'],
             'email'        => ['required','email','max:255','unique:users,email'],

--- a/app/Models/Country.php
+++ b/app/Models/Country.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Country extends Model
+{
+    protected $table = 'countries';
+    public $timestamps = false;
+
+    protected $fillable = [
+        'iso',
+        'name',
+        'iso3',
+        'numcode',
+        'phonecode',
+    ];
+}

--- a/database/migrations/2025_09_03_000000_create_country_table.php
+++ b/database/migrations/2025_09_03_000000_create_country_table.php
@@ -9,21 +9,17 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('countries', function (Blueprint $table) {
-  
-    
+            // Columns matching the SQL definition provided by the user
+            $table->increments('id');                  // INT AUTO_INCREMENT PRIMARY KEY
+            $table->char('iso', 2);                    // NOT NULL
+            $table->string('name', 80);                // NOT NULL
+            $table->char('iso3', 3)->nullable();       // DEFAULT NULL
+            $table->smallInteger('numcode')->nullable();
+            $table->unsignedInteger('phonecode');
 
-            // Columns
-            $table->increments('id');                     // INT(11) AUTO_INCREMENT
-            $table->char('iso', 2);                       // NOT NULL
-            $table->string('name', 80);                   // NOT NULL
-            $table->string('nicename', 80);               // NOT NULL
-            $table->char('iso3', 3)->nullable();          // DEFAULT NULL
-            $table->smallInteger('numcode')->nullable();  // DEFAULT NULL
-            $table->integer('phonecode')->unsigned();     // NOT NULL
-
-            // Indexes / constraints (optional but useful)
+            // Indexes / constraints
             $table->unique('iso');
-            $table->unique('iso3');       // iso3 is unique per country; remove if you expect duplicates
+            $table->unique('iso3');
             $table->index('numcode');
             $table->index('phonecode');
         });
@@ -31,6 +27,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('country');
+        Schema::dropIfExists('countries');
     }
 };

--- a/database/seeders/CountrySeeder.php
+++ b/database/seeders/CountrySeeder.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class CountrySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $countries = [
+            ['iso' => 'US', 'name' => 'United States', 'iso3' => 'USA', 'numcode' => 840, 'phonecode' => 1],
+            ['iso' => 'CA', 'name' => 'Canada',        'iso3' => 'CAN', 'numcode' => 124, 'phonecode' => 1],
+            ['iso' => 'GB', 'name' => 'United Kingdom','iso3' => 'GBR', 'numcode' => 826, 'phonecode' => 44],
+            ['iso' => 'AU', 'name' => 'Australia',     'iso3' => 'AUS', 'numcode' => 36,  'phonecode' => 61],
+            ['iso' => 'IN', 'name' => 'India',         'iso3' => 'IND', 'numcode' => 356, 'phonecode' => 91],
+            ['iso' => 'DE', 'name' => 'Germany',       'iso3' => 'DEU', 'numcode' => 276, 'phonecode' => 49],
+            ['iso' => 'FR', 'name' => 'France',        'iso3' => 'FRA', 'numcode' => 250, 'phonecode' => 33],
+            ['iso' => 'JP', 'name' => 'Japan',         'iso3' => 'JPN', 'numcode' => 392, 'phonecode' => 81],
+            ['iso' => 'CN', 'name' => 'China',         'iso3' => 'CHN', 'numcode' => 156, 'phonecode' => 86],
+            ['iso' => 'BR', 'name' => 'Brazil',        'iso3' => 'BRA', 'numcode' => 76,  'phonecode' => 55],
+        ];
+
+        DB::table('countries')->insert($countries);
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -6,6 +6,9 @@ use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
+// Additional seeders
+use Database\Seeders\CountrySeeder;
+
 class DatabaseSeeder extends Seeder
 {
     /**
@@ -13,8 +16,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call(CountrySeeder::class);
 
+        // Example user for testing purposes
         User::factory()->create([
             'name' => 'Test User',
             'email' => 'test@example.com',

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -137,7 +137,12 @@
             </div>
 
             <div class="form-floating mb-1">
-              <input type="text" name="country" class="form-control" id="country" placeholder="Country" required>
+              <select name="country" class="form-select" id="country" required>
+                <option value="" disabled selected>Select Country</option>
+                @foreach($countries as $country)
+                  <option value="{{ $country->name }}">{{ $country->name }}</option>
+                @endforeach
+              </select>
               <label for="country">Country</label>
             </div>
             <div id="country_error" class="error-message"></div>


### PR DESCRIPTION
## Summary
- Add Country model and migration for ISO country data
- Seed sample countries and load them dynamically on registration
- Replace country text input with dynamic select and validate against table

## Testing
- `composer install`
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b82d0f245c8327ad90433e1dd4444e