### PR TITLE
Fix CSRF token for registration and login forms

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -112,8 +112,7 @@
       <p class="text-center text-muted mb-4">Welcome back — enter your credentials to continue.</p>
 
       <form id="loginForm" novalidate>
-        <input type="hidden" name="_token" value="dqiXSHcP7rwGlEqKXIvz82w3pAIt7OEs7OQScHqU" autocomplete="off">
-
+          @csrf
         <div class="form-floating mb-2">
           <input type="email" name="email" class="form-control" id="email" placeholder="name@example.com" required>
           <label for="email">Email address</label>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -117,8 +117,7 @@
           <p class="text-center text-muted mb-4">Join PDFOneLink in minutes.</p>
 
           <form id="registerForm" novalidate>
-            <input type="hidden" name="_token" value="nlvhZBZnGZLoNkwuSraacLRdqWjYa1tHPCusv9d3" autocomplete="off">
-
+            @csrf
             <div class="row g-3">
               <div class="col-md-6">
                 <div class="form-floating mb-1">


### PR DESCRIPTION
## Summary
- Replace hard-coded CSRF tokens with Blade `@csrf` directive in registration and login views to prevent 419 Page Expired errors

## Testing
- `php artisan test`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b82eac4c548327afb0d01a8e2d2cea