### PR TITLE
Fix registration failing with 302 redirects

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -345,7 +345,10 @@
       try{
         const res = await fetch(@json(route('register.store')), {
           method:'POST',
-          headers:{ 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content') },
+          headers:{
+            'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
+            'Accept': 'application/json'
+          },
           body:data
         });
         let result = {};


### PR DESCRIPTION
## Summary
- ensure registration form requests JSON to avoid 302 redirect on validation errors

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b831b46d788327b0769d47310bd701