### PR TITLE
Fix login authentication by avoiding double password hashing

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -8,7 +8,6 @@ use App\Models\Country;
 use App\Rules\Captcha;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 use Carbon\Carbon;
 
@@ -60,7 +59,7 @@ class RegisterController extends Controller
                 'last_name'    => $validated['last_name'],
                 'company'      => $validated['company'],
                 'email'        => $validated['email'],
-                'password'     => Hash::make($validated['password']),
+                'password'     => $validated['password'],
                 'agreed_terms' => true,
             ]);
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -3,7 +3,6 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
@@ -23,11 +22,20 @@ class UserFactory extends Factory
      */
     public function definition(): array
     {
+        $first = fake()->firstName();
+        $last  = fake()->lastName();
         return [
-            'name' => fake()->name(),
+            'use_id' => str_pad((string) fake()->numberBetween(0, 99999999), 8, '0', STR_PAD_LEFT)
+                       . str_pad((string) fake()->numberBetween(0, 99999999), 8, '0', STR_PAD_LEFT),
+            'first_name' => $first,
+            'last_name' => $last,
+            'country' => fake()->country(),
+            'company' => fake()->company(),
+            'name' => "$first $last",
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
-            'password' => static::$password ??= Hash::make('password'),
+            'password' => static::$password ??= 'password',
+            'agreed_terms' => true,
             'remember_token' => Str::random(10),
         ];
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,7 @@
         <env name="CACHE_STORE" value="array"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
+        <env name="APP_KEY" value="base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_login_with_correct_credentials(): void
+    {
+        $password = 'secret123';
+        $user = User::factory()->create([
+            'password' => $password,
+        ]);
+
+        $response = $this->postJson('/login', [
+            'email' => $user->email,
+            'password' => $password,
+        ]);
+
+        $response->assertOk()->assertJson(['success' => true]);
+        $this->assertAuthenticatedAs($user);
+    }
+}


### PR DESCRIPTION
## Summary
- remove manual password hashing in registration to fix authentication
- update user factory and test environment for consistent password handling
- add feature test ensuring users can log in with valid credentials

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b83333bf60832793a5e3901470d804