### PR TITLE
Add admin dashboard with user management

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+
+class DashboardController extends Controller
+{
+    public function index()
+    {
+        return view('admin.dashboard.index');
+    }
+}

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Models\Document;
+
+class UserController extends Controller
+{
+    public function index()
+    {
+        $users = User::paginate(15);
+        return view('admin.users.index', compact('users'));
+    }
+
+    public function files(User $user)
+    {
+        $documents = Document::where('user_id', $user->id)->paginate(15);
+        return view('admin.users.files', compact('user', 'documents'));
+    }
+}

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -33,7 +33,12 @@ class LoginController extends Controller
             Session::put('user_name', $user->first_name ?? $user->name ?? '');
             Session::put('use_id', $user->use_id ?? null);
 
-            return response()->json(['success' => true]);
+            $redirect = $user->is_admin ? route('admin.dashboard') : route('dashboard');
+
+            return response()->json([
+                'success' => true,
+                'redirect' => $redirect,
+            ]);
         }
 
         return response()->json(['error' => 'Invalid credentials'], 422);

--- a/app/Http/Middleware/AdminMiddleware.php
+++ b/app/Http/Middleware/AdminMiddleware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class AdminMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (!Auth::check() || !Auth::user()->is_admin) {
+            abort(403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -18,7 +18,7 @@ class User extends Authenticatable
      * @var list<string>
      */
     protected $fillable = [
-        'use_id','country','first_name','last_name','company','email','password','agreed_terms'
+        'use_id','country','first_name','last_name','company','email','password','agreed_terms','is_admin'
     ];
 
     /**
@@ -41,6 +41,7 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'is_admin' => 'boolean',
         ];
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -36,6 +36,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= 'password',
             'agreed_terms' => true,
+            'is_admin' => false,
             'remember_token' => Str::random(10),
         ];
     }

--- a/database/migrations/2025_09_07_000000_add_is_admin_to_users_table.php
+++ b/database/migrations/2025_09_07_000000_add_is_admin_to_users_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('agreed_terms');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,5 +23,12 @@ class DatabaseSeeder extends Seeder
             'name' => 'Test User',
             'email' => 'test@example.com',
         ]);
+
+        // Admin user
+        User::factory()->create([
+            'name' => 'Admin',
+            'email' => 'admin@example.com',
+            'is_admin' => true,
+        ]);
     }
 }

--- a/resources/views/admin/dashboard/index.blade.php
+++ b/resources/views/admin/dashboard/index.blade.php
@@ -1,0 +1,10 @@
+@extends('admin.layouts.app')
+
+@section('title', 'Dashboard')
+
+@section('content')
+<div class="p-4">
+  <h1 class="h3 mb-4">Admin Dashboard</h1>
+  <p>Welcome, {{ auth()->user()->name }}.</p>
+</div>
+@endsection

--- a/resources/views/admin/layouts/app.blade.php
+++ b/resources/views/admin/layouts/app.blade.php
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>@yield('title', 'Admin Dashboard')</title>
+
+  {{-- Favicons --}}
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('assets/favicon_io/apple-touch-icon.png') }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('assets/favicon_io/favicon-32x32.png') }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('assets/favicon_io/favicon-16x16.png') }}">
+  <link rel="manifest" href="{{ asset('assets/favicon_io/site.webmanifest') }}">
+  <link rel="shortcut icon" href="{{ asset('assets/favicon_io/favicon.ico') }}">
+
+  <!-- DM Sans + Bootstrap + Icons -->
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+
+  <!-- Custom CSS -->
+  <link href="{{ asset('assets/vendorapp/css/style.css') }}" rel="stylesheet">
+  
+  @stack('styles')
+</head>
+<body>
+  <div class="app">
+    <!-- Sidebar -->
+    @include('admin.layouts.partials.sidebar')
+
+    <div class="overlay" id="overlay"></div>
+
+    <!-- Main -->
+    <main class="main" id="mainContent">
+      <!-- Topbar -->
+      @include('admin.layouts.partials.header')
+
+      <!-- Content -->
+      @yield('content')
+
+      <!-- Footer -->
+      @include('admin.layouts.partials.footer')
+    </main>
+  </div>
+
+  <!-- Scripts -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ asset('assets/vendorapp/js/main.js') }}"></script>
+  
+  @stack('scripts')
+</body>
+</html>

--- a/resources/views/admin/layouts/partials/footer.blade.php
+++ b/resources/views/admin/layouts/partials/footer.blade.php
@@ -1,0 +1,3 @@
+<footer class="footer">
+  Copyright © onelinkpdf.com {{ date('Y') }}
+</footer>

--- a/resources/views/admin/layouts/partials/header.blade.php
+++ b/resources/views/admin/layouts/partials/header.blade.php
@@ -1,0 +1,72 @@
+<!-- Topbar -->
+<div class="topbar">
+  <button class="btn icon-btn" id="toggleSidebar" aria-label="Toggle sidebar"><i class="bi bi-list"></i></button>
+
+  <!-- Search bar - visible on desktop, hidden on mobile -->
+  <div class="search">
+    <i class="bi bi-search"></i>
+    <input class="form-control" placeholder="Search" />
+  </div>
+
+  <div class="topbar-icons">
+    <button class="icon-btn"><i class="bi bi-gear"></i></button>
+
+    <!-- Notification Dropdown -->
+    <div class="dropdown">
+      <button class="icon-btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="bi bi-bell"></i>
+      </button>
+      <div class="dropdown-menu dropdown-menu-end notif-menu shadow-sm mt-2">
+        <div class="notif-head">
+          <span>Notifications</span><a href="#" class="notif-clear">Clear All</a>
+        </div>
+        <div class="notif-list">
+          <div class="notif-item">
+            <div class="notif-avatar"><i class="bi bi-person"></i></div>
+            <div class="notif-body">
+              <div class="notif-name">Josephine Thompson</div>
+              <p class="notif-text mb-0">commented on admin panel "Wow 🤩! this admin looks good and awesome design"</p>
+            </div>
+          </div>
+          <div class="notif-item">
+            <div class="notif-avatar">D</div>
+            <div class="notif-body">
+              <div class="notif-name">Donoghue Susan</div>
+              <p class="notif-text mb-0">Hi, how are you? What about our next meeting</p>
+            </div>
+          </div>
+          <div class="notif-item">
+            <div class="notif-avatar"><img src="https://i.pravatar.cc/80?img=5" alt=""></div>
+            <div class="notif-body">
+              <div class="notif-name">Jacob Gines</div>
+              <p class="notif-text mb-0">Answered to your comment on the dashboard post</p>
+            </div>
+          </div>
+        </div>
+        <div class="notif-cta">
+          <button class="btn btn-cta">View All Notification <i class="bi bi-arrow-right-short ms-1"></i></button>
+        </div>
+      </div>
+    </div>
+
+    <!-- User dropdown -->
+    <div class="dropdown">
+      <button class="avatar-btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="Account">
+        <i class="bi bi-person-circle"></i>
+      </button>
+      <ul class="dropdown-menu dropdown-menu-end user-menu shadow-sm mt-2">
+        <li><a class="dropdown-item d-flex align-items-center" href="{{ route('profile') }}"><i class="bi bi-person me-2"></i> Profile</a></li>
+        <li><a class="dropdown-item d-flex align-items-center" href="{{ route('password.edit') }}"><i class="bi bi-key me-2"></i> Change Password</a></li>
+        <li><hr class="dropdown-divider"></li>
+        <li>
+          <form method="POST" action="{{ route('logout') }}">
+            @csrf
+            <button type="submit" class="dropdown-item d-flex align-items-center">
+              <i class="bi bi-box-arrow-right me-2"></i> Logout
+            </button>
+          </form>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>

--- a/resources/views/admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/admin/layouts/partials/sidebar.blade.php
@@ -1,0 +1,34 @@
+<aside class="sidebar" id="sidebar">
+  <a href="#" class="brand">
+    <span class="logo"><i class="bi bi-grid-1x2"></i></span>
+     <img src="{{ asset('assets/logo/onelinkpdf-logo.png') }}"
+         alt="ONELINKPDF logo"
+         class="brand-logo" style="height: 35px;">
+  </a>
+  
+
+  <!-- Close button for sidebar (visible on mobile) -->
+  <button class="sidebar-close" id="sidebarClose">
+    <i class="bi bi-x-lg"></i>
+  </button>
+  
+  <!-- NEW MENU -->
+  <nav class="nav flex-column gap-1" id="mainNav">
+    <div class="side-title">GENERAL</div>
+    <a class="nav-link {{ request()->routeIs('admin.dashboard') ? 'active' : '' }}" href="{{ route('admin.dashboard') }}">
+      <i class="bi bi-speedometer2"></i> <span>Dashboard</span>
+    </a>
+    <a class="nav-link {{ request()->routeIs('admin.users.*') ? 'active' : '' }}" href="{{ route('admin.users.index') }}">
+      <i class="bi bi-people"></i> <span>Users</span>
+    </a>
+  </nav>
+
+  <div class="bottom">
+    <form method="POST" action="{{ route('logout') }}">
+      @csrf
+      <button type="submit" class="logout">
+        <i class="bi bi-box-arrow-right"></i> <span>Logout</span>
+      </button>
+    </form>
+  </div>
+</aside>

--- a/resources/views/admin/users/files.blade.php
+++ b/resources/views/admin/users/files.blade.php
@@ -1,0 +1,32 @@
+@extends('admin.layouts.app')
+
+@section('title', 'User Files')
+
+@section('content')
+<div class="p-4">
+  <h1 class="h3 mb-4">Files for {{ $user->name }}</h1>
+  <div class="table-responsive">
+    <table class="table align-middle">
+      <thead>
+        <tr>
+          <th>Filename</th>
+          <th>Size</th>
+          <th>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        @forelse($documents as $doc)
+        <tr>
+          <td>{{ $doc->filename }}</td>
+          <td>{{ number_format($doc->size) }} bytes</td>
+          <td>{{ $doc->updated_at }}</td>
+        </tr>
+        @empty
+        <tr><td colspan="3" class="text-muted text-center">No files found.</td></tr>
+        @endforelse
+      </tbody>
+    </table>
+  </div>
+  {{ $documents->links() }}
+</div>
+@endsection

--- a/resources/views/admin/users/index.blade.php
+++ b/resources/views/admin/users/index.blade.php
@@ -1,0 +1,34 @@
+@extends('admin.layouts.app')
+
+@section('title', 'Users')
+
+@section('content')
+<div class="p-4">
+  <h1 class="h3 mb-4">Users</h1>
+  <div class="table-responsive">
+    <table class="table align-middle">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Name</th>
+          <th>Email</th>
+          <th>Company</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        @foreach($users as $user)
+        <tr>
+          <td>{{ $user->id }}</td>
+          <td>{{ $user->name }}</td>
+          <td>{{ $user->email }}</td>
+          <td>{{ $user->company }}</td>
+          <td><a href="{{ route('admin.users.files', $user) }}" class="btn btn-sm btn-dark">Files</a></td>
+        </tr>
+        @endforeach
+      </tbody>
+    </table>
+  </div>
+  {{ $users->links() }}
+</div>
+@endsection

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -235,7 +235,8 @@
 
         if (res.ok && result.success) {
           showToast('Login successful. Redirecting...', 'Success', 'success');
-          setTimeout(() => window.location = BASE + '/vendor/dashboard', 1000);
+          const redirect = result.redirect || (BASE + '/vendor/dashboard');
+          setTimeout(() => window.location = redirect, 1000);
         } else {
           showToast(result.error || 'Login failed.', 'Error', 'danger');
         }

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,8 @@ use App\Http\Controllers\Vendor\DocumentController; // files + public viewer
 use App\Http\Controllers\Vendor\AnalyticsController;
 use App\Http\Controllers\Vendor\PlanController;
 use App\Http\Controllers\Vendor\HelpRequestController;
+use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
+use App\Http\Controllers\Admin\UserController as AdminUserController;
 
 /* ------------------------- Guest (auth) ------------------------- */
 Route::middleware('guest')->group(function () {
@@ -81,6 +83,13 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::get('help/manage',       [HelpRequestController::class, 'manage'])->name('vendor.help.manage');
     Route::get('help/manage/list',  [HelpRequestController::class, 'manageList'])->name('vendor.help.manage.list');
     Route::post('help/store',       [HelpRequestController::class, 'store'])->name('vendor.help.store');
+});
+
+/* ------------------------- Admin dashboard ------------------------- */
+Route::prefix('admin')->middleware(['auth','admin'])->name('admin.')->group(function () {
+    Route::get('dashboard', [AdminDashboardController::class, 'index'])->name('dashboard');
+    Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
+    Route::get('users/{user}/files', [AdminUserController::class, 'files'])->name('users.files');
 });
 
 /* ------------------------- Public viewer (no auth) ------------------------- */


### PR DESCRIPTION
## Summary
- allow marking users as admins via new `is_admin` field
- secure admin pages with middleware and add dashboard plus user management views
- redirect login based on role

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b838e9dd708327a66dbf8865e475d5