### PR TITLE
Remove file deletion option from admin user files page

### DIFF
--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -92,22 +92,4 @@ class UserController extends Controller
         return response()->json(['url' => $url]);
     }
 
-    public function delete(User $user, Request $request)
-    {
-        $request->validate(['ids' => 'required|array', 'ids.*' => 'integer']);
-
-        $docs = Document::where('user_id', $user->id)
-            ->whereIn('id', $request->ids)
-            ->get();
-
-        foreach ($docs as $doc) {
-            $full = public_path($doc->filepath);
-            if (is_file($full)) {
-                @unlink($full);
-            }
-            $doc->delete();
-        }
-
-        return response()->json(['success' => true]);
-    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -92,7 +92,6 @@ Route::prefix('admin')->middleware(['auth','admin'])->name('admin.')->group(func
     Route::get('users/{user}/files', [AdminUserController::class, 'files'])->name('users.files');
     Route::get('users/{user}/files/list', [AdminUserController::class, 'filesList'])->name('users.files.list');
     Route::post('users/{user}/files/generate-link', [AdminUserController::class, 'generateLink'])->name('users.files.generate');
-    Route::post('users/{user}/files/delete', [AdminUserController::class, 'delete'])->name('users.files.delete');
 });
 
 /* ------------------------- Public viewer (no auth) ------------------------- */


### PR DESCRIPTION
## Summary
- drop unused admin route for deleting user files
- strip delete controls and related JS from the admin user files view
- remove file delete handler from Admin\UserController

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b86251e3348327991e2afcf1087a5a