### PR TITLE
feat: add user plan list in admin

### DIFF
--- a/app/Http/Controllers/Admin/UserPlanController.php
+++ b/app/Http/Controllers/Admin/UserPlanController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\UserPlan;
+use Illuminate\Http\Request;
+
+class UserPlanController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = UserPlan::with(['user', 'plan']);
+        if ($search = $request->input('search')) {
+            $query->where(function ($q) use ($search) {
+                $q->whereHas('user', function ($u) use ($search) {
+                    $u->where('name', 'like', "%{$search}%");
+                })->orWhereHas('plan', function ($p) use ($search) {
+                    $p->where('name', 'like', "%{$search}%");
+                });
+            });
+        }
+        $userPlans = $query->latest()->paginate(15)->withQueryString();
+        return view('admin.user_plans.index', compact('userPlans', 'search'));
+    }
+}

--- a/resources/views/admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/admin/layouts/partials/sidebar.blade.php
@@ -21,6 +21,9 @@
     <a class="nav-link {{ request()->routeIs('admin.users.*') ? 'active' : '' }}" href="{{ route('admin.users.index') }}">
       <i class="bi bi-people"></i> <span>Users</span>
     </a>
+    <a class="nav-link {{ request()->routeIs('admin.user-plans.*') ? 'active' : '' }}" href="{{ route('admin.user-plans.index') }}">
+      <i class="bi bi-gem"></i> <span>User Plans</span>
+    </a>
   </nav>
 
   <div class="bottom">

--- a/resources/views/admin/user_plans/index.blade.php
+++ b/resources/views/admin/user_plans/index.blade.php
@@ -1,0 +1,58 @@
+@extends('admin.layouts.app')
+
+@section('title', 'User Plans')
+
+@section('content')
+<div class="container py-3">
+  <h1 class="h3 mb-4">User Plans</h1>
+  <div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+      <span class="fw-semibold"><i class="bi bi-gem"></i> All Plans</span>
+      <form id="searchForm" class="d-flex" style="max-width:300px;">
+        <input id="searchInput" name="search" value="{{ $search }}" type="text" class="form-control form-control-sm" placeholder="Search...">
+      </form>
+    </div>
+    <div class="table-responsive">
+      <table class="table table-striped mb-0">
+        <thead>
+          <tr>
+            <th>User</th>
+            <th>Plan</th>
+            <th>Start Date</th>
+            <th>End Date</th>
+            <th>Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          @forelse($userPlans as $up)
+          <tr>
+            <td>{{ $up->user?->name }}</td>
+            <td>{{ $up->plan?->name }}</td>
+            <td>{{ $up->start_date }}</td>
+            <td>{{ $up->end_date ?? '-' }}</td>
+            <td>{{ $up->status == 1 ? 'Active' : 'Inactive' }}</td>
+          </tr>
+          @empty
+          <tr>
+            <td colspan="5" class="text-center text-muted">No plans found.</td>
+          </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <nav class="mt-3" aria-label="User plans pagination">
+    {{ $userPlans->onEachSide(1)->links('pagination::bootstrap-5') }}
+  </nav>
+</div>
+
+@push('scripts')
+<script>
+document.getElementById('searchInput').addEventListener('input', function(){
+  document.getElementById('searchForm').submit();
+});
+</script>
+@endpush
+@endsection
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use App\Http\Controllers\Vendor\PlanController;
 use App\Http\Controllers\Vendor\HelpRequestController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
+use App\Http\Controllers\Admin\UserPlanController as AdminUserPlanController;
 
 /* ------------------------- Guest (auth) ------------------------- */
 Route::middleware('guest')->group(function () {
@@ -92,6 +93,7 @@ Route::prefix('admin')->middleware(['auth','admin'])->name('admin.')->group(func
     Route::get('users/{user}/files', [AdminUserController::class, 'files'])->name('users.files');
     Route::get('users/{user}/files/list', [AdminUserController::class, 'filesList'])->name('users.files.list');
     Route::post('users/{user}/files/generate-link', [AdminUserController::class, 'generateLink'])->name('users.files.generate');
+    Route::get('user-plans', [AdminUserPlanController::class, 'index'])->name('user-plans.index');
 });
 
 /* ------------------------- Public viewer (no auth) ------------------------- */


### PR DESCRIPTION
## Summary
- add Admin\UserPlanController to list plans
- expose user plan list via admin route and sidebar link
- display user, plan, dates and status in new view

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b8639c6f408327bc69cae7dc91f502