### PR TITLE
Add vendor dashboard notifications

### DIFF
--- a/app/Http/Controllers/Vendor/NotificationController.php
+++ b/app/Http/Controllers/Vendor/NotificationController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use App\Models\Notification;
+use Illuminate\Support\Facades\Auth;
+
+class NotificationController extends Controller
+{
+    /**
+     * Display a listing of notifications and mark unread as read.
+     */
+    public function index()
+    {
+        $user = Auth::user();
+
+        $notifications = Notification::forUser($user->id)
+            ->orderByDesc('created_at')
+            ->paginate(20);
+
+        Notification::forUser($user->id)
+            ->where('is_read', false)
+            ->update(['is_read' => true, 'read_at' => now()]);
+
+        return view('vendor.notifications.index', compact('notifications'));
+    }
+}
+

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Notification extends Model
+{
+    /**
+     * Indicates if the model should be timestamped.
+     */
+    public $timestamps = false;
+
+    /**
+     * The attributes that are mass assignable.
+     */
+    protected $fillable = [
+        'user_id',
+        'audience',
+        'title',
+        'message',
+        'type',
+        'priority',
+        'action_url',
+        'is_read',
+        'read_at',
+        'metadata',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     */
+    protected $casts = [
+        'metadata' => 'array',
+        'is_read'  => 'boolean',
+        'read_at'  => 'datetime',
+        'created_at' => 'datetime',
+    ];
+
+    /**
+     * Scope notifications that belong to a user or to all.
+     */
+    public function scopeForUser($query, $userId)
+    {
+        return $query->where(function ($q) use ($userId) {
+            $q->where('audience', 'all')
+              ->orWhere(function ($q2) use ($userId) {
+                  $q2->where('audience', 'user')
+                     ->where('user_id', $userId);
+              });
+        });
+    }
+}
+

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -1,8 +1,12 @@
 <?php
 
 namespace App\Providers;
-use Illuminate\Support\ServiceProvider;
+
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ServiceProvider;
+use App\Models\Notification;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +23,27 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-         Schema::defaultStringLength(191);
+        Schema::defaultStringLength(191);
+
+        View::composer('vendor.layouts.partials.header', function ($view) {
+            $notifications = collect();
+            $unreadCount = 0;
+
+            if ($user = Auth::user()) {
+                $notifications = Notification::forUser($user->id)
+                    ->orderByDesc('created_at')
+                    ->limit(5)
+                    ->get();
+
+                $unreadCount = Notification::forUser($user->id)
+                    ->where('is_read', false)
+                    ->count();
+            }
+
+            $view->with([
+                'notifications' => $notifications,
+                'unreadCount'   => $unreadCount,
+            ]);
+        });
     }
 }

--- a/database/migrations/2025_09_03_000000_create_notifications_table.php
+++ b/database/migrations/2025_09_03_000000_create_notifications_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('user_id')->nullable();
+            $table->enum('audience', ['user', 'all'])->default('user');
+            $table->string('title');
+            $table->text('message');
+            $table->enum('type', ['info','success','warning','error','system'])->default('info');
+            $table->unsignedTinyInteger('priority')->default(1);
+            $table->string('action_url', 1024)->nullable();
+            $table->boolean('is_read')->default(false);
+            $table->dateTime('read_at')->nullable();
+            $table->json('metadata')->nullable();
+            $table->dateTime('created_at')->useCurrent();
+
+            $table->index(['audience','user_id','is_read','created_at'], 'idx_user_unread_created');
+            $table->index('created_at', 'idx_created');
+            $table->index('user_id', 'idx_user');
+
+            $table->foreign('user_id', 'fk_notifications_user')
+                ->references('id')->on('users')
+                ->onDelete('cascade')
+                ->onUpdate('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};
+

--- a/resources/views/vendor/layouts/partials/header.blade.php
+++ b/resources/views/vendor/layouts/partials/header.blade.php
@@ -13,38 +13,28 @@
 
     <!-- Notification Dropdown -->
     <div class="dropdown">
-      <button class="icon-btn dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+      <button class="icon-btn dropdown-toggle position-relative" data-bs-toggle="dropdown" aria-expanded="false">
         <i class="bi bi-bell"></i>
+        @if($unreadCount > 0)
+          <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger">{{ $unreadCount }}</span>
+        @endif
       </button>
       <div class="dropdown-menu dropdown-menu-end notif-menu shadow-sm mt-2">
         <div class="notif-head">
-          <span>Notifications</span><a href="#" class="notif-clear">Clear All</a>
+          <span>Notifications</span><a href="{{ route('vendor.notifications.index') }}" class="notif-clear">View All</a>
         </div>
         <div class="notif-list">
-          <div class="notif-item">
-            <div class="notif-avatar"><i class="bi bi-person"></i></div>
-            <div class="notif-body">
-              <div class="notif-name">Josephine Thompson</div>
-              <p class="notif-text mb-0">commented on admin panel "Wow 🤩! this admin looks good and awesome design"</p>
+          @forelse($notifications as $note)
+            <div class="notif-item">
+              <div class="notif-avatar"><i class="bi bi-info-circle"></i></div>
+              <div class="notif-body">
+                <div class="notif-name">{{ $note->title }}</div>
+                <p class="notif-text mb-0">{{ $note->message }}</p>
+              </div>
             </div>
-          </div>
-          <div class="notif-item">
-            <div class="notif-avatar">D</div>
-            <div class="notif-body">
-              <div class="notif-name">Donoghue Susan</div>
-              <p class="notif-text mb-0">Hi, how are you? What about our next meeting</p>
-            </div>
-          </div>
-          <div class="notif-item">
-            <div class="notif-avatar"><img src="https://i.pravatar.cc/80?img=5" alt=""></div>
-            <div class="notif-body">
-              <div class="notif-name">Jacob Gines</div>
-              <p class="notif-text mb-0">Answered to your comment on the dashboard post</p>
-            </div>
-          </div>
-        </div>
-        <div class="notif-cta">
-          <button class="btn btn-cta">View All Notification <i class="bi bi-arrow-right-short ms-1"></i></button>
+          @empty
+            <div class="p-3 text-center text-muted">No notifications</div>
+          @endforelse
         </div>
       </div>
     </div>

--- a/resources/views/vendor/notifications/index.blade.php
+++ b/resources/views/vendor/notifications/index.blade.php
@@ -1,0 +1,40 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'Notifications')
+
+@section('content')
+  <div class="bw-band">
+    <ol class="bw-crumb">
+      <li><a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i>Home</a></li>
+      <li>Notifications</li>
+    </ol>
+  </div>
+
+  <div class="card">
+    <div class="card-header"><i class="bi bi-bell me-1"></i> Notifications</div>
+    <div class="card-body">
+      @if($notifications->isEmpty())
+        <p class="text-muted mb-0">No notifications found.</p>
+      @else
+        <ul class="list-group mb-3">
+          @foreach($notifications as $note)
+            <li class="list-group-item">
+              <div class="d-flex justify-content-between">
+                <div>
+                  <strong>{{ $note->title }}</strong>
+                  <div class="small text-muted">{{ $note->created_at?->format('Y-m-d H:i') }}</div>
+                  <p class="mb-0">{{ $note->message }}</p>
+                </div>
+                @if($note->action_url)
+                  <a href="{{ $note->action_url }}" class="btn btn-sm btn-primary">View</a>
+                @endif
+              </div>
+            </li>
+          @endforeach
+        </ul>
+        {{ $notifications->links() }}
+      @endif
+    </div>
+  </div>
+@endsection
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,6 +14,7 @@ use App\Http\Controllers\Vendor\DocumentController; // files + public viewer
 use App\Http\Controllers\Vendor\AnalyticsController;
 use App\Http\Controllers\Vendor\PlanController;
 use App\Http\Controllers\Vendor\HelpRequestController;
+use App\Http\Controllers\Vendor\NotificationController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Admin\UserPlanController as AdminUserPlanController;
@@ -84,6 +85,9 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::get('help/manage',       [HelpRequestController::class, 'manage'])->name('vendor.help.manage');
     Route::get('help/manage/list',  [HelpRequestController::class, 'manageList'])->name('vendor.help.manage.list');
     Route::post('help/store',       [HelpRequestController::class, 'store'])->name('vendor.help.store');
+
+    // Notifications
+    Route::get('notifications', [NotificationController::class, 'index'])->name('vendor.notifications.index');
 });
 
 /* ------------------------- Admin dashboard ------------------------- */


### PR DESCRIPTION
## Summary
- add notifications table migration and model
- display user notifications in vendor header
- list and mark notifications as read from new controller

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/onepdf-app-laravel/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b86c7ea7ac8327945d44497230d3b0