### PR TITLE
Add dashboard link to admin header

### DIFF
--- a/resources/views/admin/layouts/partials/header.blade.php
+++ b/resources/views/admin/layouts/partials/header.blade.php
@@ -1,6 +1,7 @@
 <!-- Topbar -->
 <div class="topbar">
   <button class="btn icon-btn" id="toggleSidebar" aria-label="Toggle sidebar"><i class="bi bi-list"></i></button>
+  <a href="{{ route('admin.dashboard') }}" class="ms-2 text-decoration-none">Dashboard</a>
 
   <!-- Search bar - visible on desktop, hidden on mobile -->
   <div class="search">


### PR DESCRIPTION
## Summary
- add direct link to the admin dashboard in the header

## Testing
- `composer test` (warnings: failed to open .env file)

------
https://chatgpt.com/codex/tasks/task_e_68b86e2e21888327b8552e95049d1a3c