### PR TITLE
Implement password reset flow with Hostinger SMTP configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,13 +47,13 @@ REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 
-MAIL_MAILER=log
-MAIL_SCHEME=null
-MAIL_HOST=127.0.0.1
-MAIL_PORT=2525
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_MAILER=smtp
+MAIL_SCHEME=tls
+MAIL_HOST=smtp.hostinger.com
+MAIL_PORT=587
+MAIL_USERNAME="your_hostinger_username"
+MAIL_PASSWORD="your_hostinger_password"
+MAIL_FROM_ADDRESS="no-reply@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
 

--- a/app/Http/Controllers/Auth/PasswordResetController.php
+++ b/app/Http/Controllers/Auth/PasswordResetController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Password;
+
+class PasswordResetController extends Controller
+{
+    /**
+     * Display the password reset link request form.
+     */
+    public function request()
+    {
+        return view('auth.forgot-password');
+    }
+
+    /**
+     * Handle sending of the password reset link email.
+     */
+    public function email(Request $request)
+    {
+        $request->validate(['email' => ['required', 'email']]);
+
+        $status = Password::sendResetLink(
+            $request->only('email')
+        );
+
+        return $status === Password::RESET_LINK_SENT
+            ? back()->with(['status' => __($status)])
+            : back()->withErrors(['email' => __($status)]);
+    }
+
+    /**
+     * Display the password reset form for the given token.
+     */
+    public function reset(Request $request, string $token)
+    {
+        return view('auth.reset-password', [
+            'token' => $token,
+            'email' => $request->email,
+        ]);
+    }
+
+    /**
+     * Handle an incoming new password request.
+     */
+    public function update(Request $request)
+    {
+        $request->validate([
+            'token' => ['required'],
+            'email' => ['required', 'email'],
+            'password' => ['required', 'confirmed', 'min:8'],
+        ]);
+
+        $status = Password::reset(
+            $request->only('email', 'password', 'password_confirmation', 'token'),
+            function ($user, $password) {
+                $user->forceFill([
+                    'password' => Hash::make($password),
+                ])->save();
+            }
+        );
+
+        if ($status === Password::PASSWORD_RESET) {
+            return redirect()->route('login')->with('status', __($status));
+        }
+
+        return back()->withErrors(['email' => [__($status)]]);
+    }
+}

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,0 +1,41 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Forgot Password</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light d-flex align-items-center min-vh-100">
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h3 class="card-title mb-3">Forgot your password?</h3>
+                    <p class="text-muted mb-4">Enter your email and we'll send you a reset link.</p>
+                    @if (session('status'))
+                        <div class="alert alert-success" role="alert">{{ session('status') }}</div>
+                    @endif
+                    <form method="POST" action="{{ route('password.email') }}">
+                        @csrf
+                        <div class="mb-3">
+                            <label for="email" class="form-label">Email</label>
+                            <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autofocus>
+                            @error('email')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Send Reset Link</button>
+                    </form>
+                    <div class="mt-3 text-center">
+                        <a href="{{ route('login') }}">Back to login</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -132,6 +132,10 @@
         </div>
 
         <div class="text-center mt-3">
+          <a id="forgotPasswordLink" href="#" class="text-decoration-underline">Forgot password?</a>
+        </div>
+
+        <div class="text-center mt-3">
           <span class="text-muted">Don’t have an account?</span>
           <a id="registerLink" href="#" class="fw-semibold">Create one</a>
         </div>
@@ -159,6 +163,7 @@
 
     // Wire up nav links
     document.getElementById('registerLink').href = BASE + '/register';
+    document.getElementById('forgotPasswordLink').href = BASE + '/forgot-password';
     document.getElementById('backHomeTop').href = BASE + '/';
     document.getElementById('backHomeBottom').href = BASE + '/';
 

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Reset Password</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light d-flex align-items-center min-vh-100">
+<div class="container">
+    <div class="row justify-content-center">
+        <div class="col-md-6">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h3 class="card-title mb-3">Reset password</h3>
+                    <form method="POST" action="{{ route('password.update') }}">
+                        @csrf
+                        <input type="hidden" name="token" value="{{ $token }}">
+                        <div class="mb-3">
+                            <label for="email" class="form-label">Email</label>
+                            <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ $email ?? old('email') }}" required autofocus>
+                            @error('email')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="password" class="form-label">Password</label>
+                            <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required>
+                            @error('password')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <div class="mb-3">
+                            <label for="password_confirmation" class="form-label">Confirm Password</label>
+                            <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" required>
+                        </div>
+                        <button type="submit" class="btn btn-primary w-100">Reset Password</button>
+                    </form>
+                    <div class="mt-3 text-center">
+                        <a href="{{ route('login') }}">Back to login</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,23 +1,24 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\HomeController;
-use App\Http\Controllers\Auth\RegisterController;
-use App\Http\Controllers\Auth\LoginController;
-use App\Http\Controllers\NewsletterSubscriptionController;
-use App\Http\Controllers\Vendor\DashboardController;
-use App\Http\Controllers\Vendor\ProfileController;
-use App\Http\Controllers\Vendor\PasswordController;
-use App\Http\Controllers\ContactController;
-use App\Http\Controllers\PartnershipsController;
-use App\Http\Controllers\Vendor\DocumentController; // files + public viewer
-use App\Http\Controllers\Vendor\AnalyticsController;
-use App\Http\Controllers\Vendor\PlanController;
-use App\Http\Controllers\Vendor\HelpRequestController;
-use App\Http\Controllers\Vendor\NotificationController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Admin\UserPlanController as AdminUserPlanController;
+use App\Http\Controllers\Auth\LoginController;
+use App\Http\Controllers\Auth\PasswordResetController;
+use App\Http\Controllers\Auth\RegisterController;
+use App\Http\Controllers\ContactController;
+use App\Http\Controllers\HomeController;
+use App\Http\Controllers\NewsletterSubscriptionController;
+use App\Http\Controllers\PartnershipsController;
+use App\Http\Controllers\Vendor\AnalyticsController;
+use App\Http\Controllers\Vendor\DashboardController; // files + public viewer
+use App\Http\Controllers\Vendor\DocumentController;
+use App\Http\Controllers\Vendor\HelpRequestController;
+use App\Http\Controllers\Vendor\NotificationController;
+use App\Http\Controllers\Vendor\PasswordController;
+use App\Http\Controllers\Vendor\PlanController;
+use App\Http\Controllers\Vendor\ProfileController;
+use Illuminate\Support\Facades\Route;
 
 /* ------------------------- Guest (auth) ------------------------- */
 Route::middleware('guest')->group(function () {
@@ -27,6 +28,11 @@ Route::middleware('guest')->group(function () {
 
     Route::get('/login', [LoginController::class, 'create'])->name('login');
     Route::post('/login', [LoginController::class, 'store'])->name('login.store');
+
+    Route::get('/forgot-password', [PasswordResetController::class, 'request'])->name('password.request');
+    Route::post('/forgot-password', [PasswordResetController::class, 'email'])->name('password.email');
+    Route::get('/reset-password/{token}', [PasswordResetController::class, 'reset'])->name('password.reset');
+    Route::post('/reset-password', [PasswordResetController::class, 'update'])->name('password.update');
 });
 
 /* ------------------------- Logout ------------------------- */
@@ -61,37 +67,37 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::put('password', [PasswordController::class, 'update'])->name('password.update');
 
     // Files
-    Route::get('files',                [DocumentController::class, 'index'])->name('vendor.files.index');
-    Route::get('files/list',           [DocumentController::class, 'list'])->name('vendor.files.list');
-    Route::get('files/manage',         [DocumentController::class, 'manage'])->name('vendor.files.manage');
-    Route::get('files/manage/list',    [DocumentController::class, 'manageList'])->name('vendor.files.manage.list');
-    Route::get('files/manage/{id}',    [DocumentController::class, 'show'])->name('vendor.files.show');
-    Route::put('files/manage/{id}',    [DocumentController::class, 'update'])->name('vendor.files.update');
-    Route::post('files/upload',        [DocumentController::class, 'upload'])->name('vendor.files.upload');
-    Route::post('files/delete',        [DocumentController::class, 'destroy'])->name('vendor.files.delete');
+    Route::get('files', [DocumentController::class, 'index'])->name('vendor.files.index');
+    Route::get('files/list', [DocumentController::class, 'list'])->name('vendor.files.list');
+    Route::get('files/manage', [DocumentController::class, 'manage'])->name('vendor.files.manage');
+    Route::get('files/manage/list', [DocumentController::class, 'manageList'])->name('vendor.files.manage.list');
+    Route::get('files/manage/{id}', [DocumentController::class, 'show'])->name('vendor.files.show');
+    Route::put('files/manage/{id}', [DocumentController::class, 'update'])->name('vendor.files.update');
+    Route::post('files/upload', [DocumentController::class, 'upload'])->name('vendor.files.upload');
+    Route::post('files/delete', [DocumentController::class, 'destroy'])->name('vendor.files.delete');
     Route::post('files/generate-link', [DocumentController::class, 'generateLink'])->name('vendor.files.generate');
-    Route::get('files/embed',          [DocumentController::class, 'embed'])->name('vendor.files.embed');
+    Route::get('files/embed', [DocumentController::class, 'embed'])->name('vendor.files.embed');
 
     // Analytics
-    Route::get('analytics',                    [AnalyticsController::class, 'index'])->name('vendor.analytics.index');
-    Route::get('analytics/document/{id}',      [AnalyticsController::class, 'document'])->name('vendor.analytics.document');
-    Route::get('analytics/documents',          [AnalyticsController::class, 'documents'])->name('vendor.analytics.documents');
+    Route::get('analytics', [AnalyticsController::class, 'index'])->name('vendor.analytics.index');
+    Route::get('analytics/document/{id}', [AnalyticsController::class, 'document'])->name('vendor.analytics.document');
+    Route::get('analytics/documents', [AnalyticsController::class, 'documents'])->name('vendor.analytics.documents');
 
     // Plan
-    Route::get('plan',                 [PlanController::class, 'index'])->name('vendor.plan.index');
-    Route::post('plan/update',         [PlanController::class, 'update'])->name('vendor.plan.update');
+    Route::get('plan', [PlanController::class, 'index'])->name('vendor.plan.index');
+    Route::post('plan/update', [PlanController::class, 'update'])->name('vendor.plan.update');
 
     // Help Requests
-    Route::get('help/manage',       [HelpRequestController::class, 'manage'])->name('vendor.help.manage');
-    Route::get('help/manage/list',  [HelpRequestController::class, 'manageList'])->name('vendor.help.manage.list');
-    Route::post('help/store',       [HelpRequestController::class, 'store'])->name('vendor.help.store');
+    Route::get('help/manage', [HelpRequestController::class, 'manage'])->name('vendor.help.manage');
+    Route::get('help/manage/list', [HelpRequestController::class, 'manageList'])->name('vendor.help.manage.list');
+    Route::post('help/store', [HelpRequestController::class, 'store'])->name('vendor.help.store');
 
     // Notifications
     Route::get('notifications', [NotificationController::class, 'index'])->name('vendor.notifications.index');
 });
 
 /* ------------------------- Admin dashboard ------------------------- */
-Route::prefix('admin')->middleware(['auth','admin'])->name('admin.')->group(function () {
+Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(function () {
     Route::get('dashboard', [AdminDashboardController::class, 'index'])->name('dashboard');
     Route::get('users', [AdminUserController::class, 'index'])->name('users.index');
     Route::get('users/{user}/files', [AdminUserController::class, 'files'])->name('users.files');
@@ -101,11 +107,11 @@ Route::prefix('admin')->middleware(['auth','admin'])->name('admin.')->group(func
 });
 
 /* ------------------------- Public viewer (no auth) ------------------------- */
-Route::get('/view',    [DocumentController::class, 'viewer'])->name('public.viewer');
+Route::get('/view', [DocumentController::class, 'viewer'])->name('public.viewer');
 Route::get('/get-pdf', [DocumentController::class, 'streamBySlug'])->name('public.pdf');
 
 // 🔹 NEW: analytics endpoint used by the viewer JS
-Route::post('/track',  [DocumentController::class, 'track'])
+Route::post('/track', [DocumentController::class, 'track'])
     ->name('public.track')
     ->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
 


### PR DESCRIPTION
## Summary
- add password reset controller and routes
- add views and link for forgot/reset password
- configure Hostinger SMTP defaults in `.env.example`

## Testing
- `./vendor/bin/phpunit`
- `./vendor/bin/pint routes/web.php app/Http/Controllers/Auth/PasswordResetController.php resources/views/auth/login.blade.php resources/views/auth/forgot-password.blade.php resources/views/auth/reset-password.blade.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8754276f08327803f9b530ebc9a84