### PR TITLE
Resolve password reset route conflict

### DIFF
--- a/app/Http/Controllers/Vendor/PasswordController.php
+++ b/app/Http/Controllers/Vendor/PasswordController.php
@@ -35,6 +35,6 @@ class PasswordController extends Controller
             ]);
         }
 
-        return redirect()->route('password.edit')->with('status', 'Password updated successfully.');
+        return redirect()->route('vendor.password.edit')->with('status', 'Password updated successfully.');
     }
 }

--- a/resources/views/admin/layouts/partials/header.blade.php
+++ b/resources/views/admin/layouts/partials/header.blade.php
@@ -57,7 +57,7 @@
       </button>
       <ul class="dropdown-menu dropdown-menu-end user-menu shadow-sm mt-2">
         <li><a class="dropdown-item d-flex align-items-center" href="{{ route('profile') }}"><i class="bi bi-person me-2"></i> Profile</a></li>
-        <li><a class="dropdown-item d-flex align-items-center" href="{{ route('password.edit') }}"><i class="bi bi-key me-2"></i> Change Password</a></li>
+        <li><a class="dropdown-item d-flex align-items-center" href="{{ route('vendor.password.edit') }}"><i class="bi bi-key me-2"></i> Change Password</a></li>
         <li><hr class="dropdown-divider"></li>
         <li>
           <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/auth/reset-password.blade.php
+++ b/resources/views/auth/reset-password.blade.php
@@ -89,7 +89,7 @@
       <h3 class="text-center mb-3">Reset Password</h3>
       <p class="text-center text-muted mb-4">Create a new password to secure your account.</p>
 
-      <form id="resetForm" method="POST" action="{{ route('password.update') }}" novalidate>
+      <form id="resetForm" method="POST" action="{{ url('/reset-password') }}" novalidate>
         @csrf
         <input type="hidden" name="token" value="{{ $token }}">
 

--- a/resources/views/vendor/layouts/partials/header.blade.php
+++ b/resources/views/vendor/layouts/partials/header.blade.php
@@ -46,7 +46,7 @@
       </button>
       <ul class="dropdown-menu dropdown-menu-end user-menu shadow-sm mt-2">
         <li><a class="dropdown-item d-flex align-items-center" href="{{ route('profile') }}"><i class="bi bi-person me-2"></i> Profile</a></li>
-        <li><a class="dropdown-item d-flex align-items-center" href="{{ route('password.edit') }}"><i class="bi bi-key me-2"></i> Change Password</a></li>
+        <li><a class="dropdown-item d-flex align-items-center" href="{{ route('vendor.password.edit') }}"><i class="bi bi-key me-2"></i> Change Password</a></li>
         <li><hr class="dropdown-divider"></li>
         <li>
           <form method="POST" action="{{ route('logout') }}">

--- a/resources/views/vendor/layouts/partials/sidebar.blade.php
+++ b/resources/views/vendor/layouts/partials/sidebar.blade.php
@@ -34,15 +34,15 @@
     <div class="side-title">ACCOUNT</div>
   
     <!-- Settings collapsible -->
-    <a class="nav-link {{ request()->routeIs('profile') || request()->routeIs('password.*') ? 'active' : '' }}" data-bs-toggle="collapse" href="#settingsMenu" role="button" aria-expanded="{{ request()->routeIs('profile') || request()->routeIs('password.*') ? 'true' : 'false' }}" aria-controls="settingsMenu">
+    <a class="nav-link {{ request()->routeIs('profile') || request()->routeIs('vendor.password.*') ? 'active' : '' }}" data-bs-toggle="collapse" href="#settingsMenu" role="button" aria-expanded="{{ request()->routeIs('profile') || request()->routeIs('vendor.password.*') ? 'true' : 'false' }}" aria-controls="settingsMenu">
       <i class="bi bi-gear"></i> <span>Settings</span>
       <span class="ms-auto"><i class="bi bi-caret-down-fill"></i></span>
     </a>
-    <div class="collapse subnav {{ request()->routeIs('profile') || request()->routeIs('password.*') ? 'show' : '' }}" id="settingsMenu" data-bs-parent="#mainNav">
+    <div class="collapse subnav {{ request()->routeIs('profile') || request()->routeIs('vendor.password.*') ? 'show' : '' }}" id="settingsMenu" data-bs-parent="#mainNav">
       <a class="nav-link {{ request()->routeIs('profile') ? 'active' : '' }}" href="{{ route('profile') }}">
         <i class="bi bi-person me-1"></i> <span>Profile</span>
       </a>
-      <a class="nav-link {{ request()->routeIs('password.edit') ? 'active' : '' }}" href="{{ route('password.edit') }}">
+      <a class="nav-link {{ request()->routeIs('vendor.password.edit') ? 'active' : '' }}" href="{{ route('vendor.password.edit') }}">
         <i class="bi bi-key me-1"></i> <span>Change Password</span>
       </a>
     </div>

--- a/resources/views/vendor/password/edit.blade.php
+++ b/resources/views/vendor/password/edit.blade.php
@@ -98,7 +98,7 @@
         </div>
       </div>
 
-      <form id="password-form" method="POST" action="{{ route('password.update') }}" novalidate>
+      <form id="password-form" method="POST" action="{{ route('vendor.password.update') }}" novalidate>
         @csrf
         @method('PUT')
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,8 +63,8 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::get('profile', [ProfileController::class, 'edit'])->name('profile');
     Route::put('profile', [ProfileController::class, 'update'])->name('profile.update');
 
-    Route::get('password', [PasswordController::class, 'edit'])->name('password.edit');
-    Route::put('password', [PasswordController::class, 'update'])->name('password.update');
+    Route::get('password', [PasswordController::class, 'edit'])->name('vendor.password.edit');
+    Route::put('password', [PasswordController::class, 'update'])->name('vendor.password.update');
 
     // Files
     Route::get('files', [DocumentController::class, 'index'])->name('vendor.files.index');


### PR DESCRIPTION
## Summary
- Rename vendor password routes to `vendor.password.edit` and `vendor.password.update`
- Update vendor templates and controller to use the new route names
- Prevent `/reset-password` form from posting to vendor route

## Testing
- `APP_URL=http://localhost php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_68b882ac15b483279c94c2331efa7b25