### PR TITLE
Use local brand icons

### DIFF
--- a/resources/views/features.blade.php
+++ b/resources/views/features.blade.php
@@ -324,12 +324,12 @@
       </div>
 
       <div class="d-flex flex-wrap justify-content-center align-items-center">
-        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/slack/slack-original.svg" class="integration-logo" alt="Slack">
-        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/google/google-original.svg" class="integration-logo" alt="Google">
-        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/microsoft/microsoft-original.svg" class="integration-logo" alt="Microsoft">
-        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/salesforce/salesforce-original.svg" class="integration-logo" alt="Salesforce">
-        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/wordpress/wordpress-original.svg" class="integration-logo" alt="WordPress">
-        <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/zapier/zapier-original.svg" class="integration-logo" alt="Zapier">
+        <img src="{{ asset('assets/brand-svg/slack-original.svg') }}" class="integration-logo" alt="Slack">
+        <img src="{{ asset('assets/brand-svg/google-original.svg') }}" class="integration-logo" alt="Google">
+        <img src="{{ asset('assets/brand-svg/microsoft.svg') }}" class="integration-logo" alt="Microsoft">
+        <img src="{{ asset('assets/brand-svg/salesforce-original.svg') }}" class="integration-logo" alt="Salesforce">
+        <img src="{{ asset('assets/brand-svg/wordpress-original.svg') }}" class="integration-logo" alt="WordPress">
+        <img src="{{ asset('assets/brand-svg/zapier-icon.svg') }}" class="integration-logo" alt="Zapier">
       </div>
 
       <div class="text-center mt-5">

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -54,11 +54,11 @@
           </div>
 
           <div class="logo-strip mt-4">
-            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/slack/slack-original.svg" alt="Slack">
-            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/google/google-original.svg" alt="Google">
-            <img src="https://www.svgrepo.com/show/132023/microsoft.svg" alt="Microsoft">
-            <img src="https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/wordpress/wordpress-original.svg" alt="WordPress">
-            <img src="https://www.svgrepo.com/show/354596/zapier-icon.svg" alt="Zapier">
+            <img src="{{ asset('assets/brand-svg/slack-original.svg') }}" alt="Slack">
+            <img src="{{ asset('assets/brand-svg/google-original.svg') }}" alt="Google">
+            <img src="{{ asset('assets/brand-svg/microsoft.svg') }}" alt="Microsoft">
+            <img src="{{ asset('assets/brand-svg/wordpress-original.svg') }}" alt="WordPress">
+            <img src="{{ asset('assets/brand-svg/zapier-icon.svg') }}" alt="Zapier">
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- replace remote logo strip icons with local assets
- use local brand icons in "Works With Your Tools"

## Testing
- `php artisan test` *(fails: Request::create(): Argument #1 ($uri) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68b98d2f462c8327ab16508bdc055b9d