### PR TITLE
Fix broken links and add placeholder docs/integrations pages

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -84,6 +84,22 @@ class HomeController extends Controller
     }
 
     /**
+     * Display the documentation page.
+     */
+    public function docs()
+    {
+        return view('docs');
+    }
+
+    /**
+     * Display the integrations page.
+     */
+    public function integrations()
+    {
+        return view('integrations');
+    }
+
+    /**
      * Display the login page.
      */
     public function login()

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('title', 'Documentation - PDFOneLink')
+
+@section('content')
+<section class="section">
+  <div class="container">
+    <h1 class="mb-4">Documentation</h1>
+    <p class="text-muted">Documentation coming soon.</p>
+  </div>
+</section>
+
+<section id="api" class="section">
+  <div class="container">
+    <h2 class="mb-4">API &amp; Webhooks</h2>
+    <p class="text-muted">API reference coming soon.</p>
+  </div>
+</section>
+@endsection

--- a/resources/views/features.blade.php
+++ b/resources/views/features.blade.php
@@ -333,7 +333,7 @@
       </div>
 
       <div class="text-center mt-5">
-        <a href="{{ url('/integrations') }}" class="btn btn-brand">View All Integrations</a>
+        <a href="{{ route('integrations') }}" class="btn btn-brand">View All Integrations</a>
       </div>
     </div>
   </section>
@@ -346,7 +346,7 @@
           <h2 class="mb-4">Ready to try PDFOneLink?</h2>
           <p class="text-muted mb-4">Start sharing your PDFs securely today. No credit card required.</p>
           <div class="d-flex justify-content-center gap-3 flex-wrap">
-            <a href="{{ url('/registration') }}" class="btn btn-brand btn-lg">Get Started for Free</a>
+            <a href="{{ route('register') }}" class="btn btn-brand btn-lg">Get Started for Free</a>
             <a href="javascript:void(0)" class="btn btn-ghost btn-lg">Schedule a Demo</a>
           </div>
         </div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -270,8 +270,8 @@ export class PdfOneLinkEmbedComponent {
           </div>
 
           <div class="d-flex gap-3 mt-4">
-            <a href="{{ url('/registration') }}" class="btn btn-brand"><i class="bi bi-rocket-takeoff me-2"></i>Get started</a>
-            <a href="{{ url('/docs') }}" class="btn btn-ghost"><i class="bi bi-journal-text me-2"></i>View docs</a>
+            <a href="{{ route('register') }}" class="btn btn-brand"><i class="bi bi-rocket-takeoff me-2"></i>Get started</a>
+            <a href="{{ route('docs') }}" class="btn btn-ghost"><i class="bi bi-journal-text me-2"></i>View docs</a>
           </div>
         </div><!-- /right -->
       </div>
@@ -298,7 +298,7 @@ export class PdfOneLinkEmbedComponent {
               <li><i class="bi bi-x text-muted"></i>Permission controls</li>
               <li><i class="bi bi-x text-muted"></i>Custom branding</li>
             </ul>
-            <a href="{{ url('/registration') }}" class="btn btn-ghost w-100">Start free</a>
+            <a href="{{ route('register') }}" class="btn btn-ghost w-100">Start free</a>
           </div>
         </div>
 
@@ -314,7 +314,7 @@ export class PdfOneLinkEmbedComponent {
               <li><i class="bi bi-check2 check"></i>Custom watermark</li>
               <li><i class="bi bi-check2 check"></i>Link expiry &amp; revocation</li>
             </ul>
-            <a href="{{ url('/registration') }}" class="btn btn-brand w-100">Choose Pro</a>
+            <a href="{{ route('register') }}" class="btn btn-brand w-100">Choose Pro</a>
           </div>
         </div>
 
@@ -373,7 +373,7 @@ export class PdfOneLinkEmbedComponent {
       <div class="cta-section">
         <h2 class="fw-bold mb-3">Start sharing secure, trackable PDFs today</h2>
         <p class="text-muted mb-4">It only takes a minute to set up. No credit card required.</p>
-        <a href="{{ url('/registration') }}" class="btn btn-brand btn-lg"><i class="bi bi-rocket-takeoff me-2"></i>Create your free account</a>
+        <a href="{{ route('register') }}" class="btn btn-brand btn-lg"><i class="bi bi-rocket-takeoff me-2"></i>Create your free account</a>
       </div>
     </div>
   </section>

--- a/resources/views/integrations.blade.php
+++ b/resources/views/integrations.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('title', 'Integrations - PDFOneLink')
+
+@section('content')
+<section class="section">
+  <div class="container">
+    <h1 class="mb-4">Integrations</h1>
+    <p class="text-muted">Integration details coming soon.</p>
+  </div>
+</section>
+@endsection

--- a/resources/views/layouts/partials/footer.blade.php
+++ b/resources/views/layouts/partials/footer.blade.php
@@ -27,8 +27,8 @@
       <div class="col-6 col-lg-2">
         <h6 class="mb-4">Resources</h6>
         <ul class="list-unstyled">
-          <li><a href="{{ url('/docs') }}">Documentation</a></li>
-          <li><a href="{{ url('/docs#api') }}">API &amp; Webhooks</a></li>
+          <li><a href="{{ route('docs') }}">Documentation</a></li>
+          <li><a href="{{ route('docs') }}#api">API &amp; Webhooks</a></li>
           <li><a href="{{ url('/#demo') }}">Embed Demo</a></li>
           <li><a href="{{ url('/#faq') }}">FAQ</a></li>
         </ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,6 +48,8 @@ Route::get('/contact', [HomeController::class, 'contact'])->name('contact');
 Route::get('/partnerships', [HomeController::class, 'partnerships'])->name('partnerships');
 Route::get('/terms', [HomeController::class, 'terms'])->name('terms');
 Route::get('/privacy', [HomeController::class, 'privacy'])->name('privacy');
+Route::get('/docs', [HomeController::class, 'docs'])->name('docs');
+Route::get('/integrations', [HomeController::class, 'integrations'])->name('integrations');
 Route::post('/subscribe', [NewsletterSubscriptionController::class, 'store'])->name('subscribe');
 
 /* Contact + Partnerships (AJAX) */


### PR DESCRIPTION
## Summary
- add routes and controller actions for `/docs` and `/integrations`
- replace outdated registration, docs, and integration links with named routes
- create placeholder Documentation and Integrations views to avoid 404s

## Testing
- `APP_URL=http://localhost ./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68b9909454e083279ddfc9c1053c6a86