### PR TITLE
Add vendor dashboard documentation page

### DIFF
--- a/public/vendor-dashboard-doc.html
+++ b/public/vendor-dashboard-doc.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vendor Dashboard Guide</title>
+  <style>
+    body {font-family: Arial, sans-serif; margin: 0; line-height: 1.6; background: #f8f9fa; color: #333;}
+    header {background: #343a40; color: #fff; padding: 1rem 2rem;}
+    header h1 {margin: 0; font-size: 1.5rem;}
+    nav {background: #495057; padding: 0.5rem 2rem;}
+    nav a {color: #fff; margin-right: 1rem; text-decoration: none; font-weight: bold;}
+    section {padding: 2rem; border-bottom: 1px solid #e1e1e1; background: #fff;}
+    h2 {color: #0d6efd; margin-top: 0;}
+    .page-list {margin-left: 1rem;}
+    footer {background: #343a40; color: #fff; text-align: center; padding: 1rem;}
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Vendor Dashboard – How It Works</h1>
+  </header>
+  <nav>
+    <a href="#dashboard">Dashboard</a>
+    <a href="#files">Files</a>
+    <a href="#analytics">Analytics</a>
+    <a href="#plan">Plan</a>
+    <a href="#notifications">Notifications</a>
+    <a href="#help">Help Center</a>
+    <a href="#profile">Profile</a>
+    <a href="#password">Password</a>
+  </nav>
+  <section id="dashboard">
+    <h2>Dashboard</h2>
+    <p>The dashboard gives vendors a quick overview of their recent activity. It lists the latest uploaded documents and displays quick statistics like total documents and recent downloads.</p>
+  </section>
+  <section id="files">
+    <h2>Files</h2>
+    <p>All file management lives here.</p>
+    <ul class="page-list">
+      <li><strong>List:</strong> Browse every file you have uploaded.</li>
+      <li><strong>Upload:</strong> Add new PDF files using the upload form.</li>
+      <li><strong>Manage:</strong> Rename files, generate sharing links and delete documents you no longer need.</li>
+      <li><strong>Details:</strong> View file specific information and update metadata like title or description.</li>
+      <li><strong>Embed:</strong> Generate embeddable code snippets to display documents on external sites.</li>
+    </ul>
+  </section>
+  <section id="analytics">
+    <h2>Analytics</h2>
+    <p>Analytics pages show how your documents perform.</p>
+    <ul class="page-list">
+      <li><strong>Overview:</strong> Charts and counters summarizing views and downloads.</li>
+      <li><strong>Documents:</strong> Performance table for each document.</li>
+      <li><strong>Document Detail:</strong> Drill down into a single document’s metrics.</li>
+    </ul>
+  </section>
+  <section id="plan">
+    <h2>Plan</h2>
+    <p>The plan page displays your current subscription and available upgrades. Vendors can switch plans directly from this page.</p>
+  </section>
+  <section id="notifications">
+    <h2>Notifications</h2>
+    <p>Shows system and account notifications. Use this page to stay informed about important updates.</p>
+  </section>
+  <section id="help">
+    <h2>Help Center</h2>
+    <p>Submit support requests and view existing tickets. The manage page lists past requests for quick reference.</p>
+  </section>
+  <section id="profile">
+    <h2>Profile</h2>
+    <p>Edit personal information like name and email. Changes here affect your account settings.</p>
+  </section>
+  <section id="password">
+    <h2>Password</h2>
+    <p>Change your account password. Enter the current password and a new password to update.</p>
+  </section>
+  <footer>
+    <p>&copy; 2024 OnePDF Vendor Dashboard</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- document each vendor dashboard page in a static HTML guide

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b9bb22567483278047b567bcc4e11c