### PR TITLE
Allow linking lead forms to document links

### DIFF
--- a/app/Http/Controllers/LeadCaptureController.php
+++ b/app/Http/Controllers/LeadCaptureController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Lead;
+use App\Models\Link;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+
+class LeadCaptureController extends Controller
+{
+    public function store(Request $request)
+    {
+        $request->validate([
+            'slug' => 'required|string',
+            'name' => 'required|string|max:255',
+            'email' => 'nullable|email|max:255',
+        ]);
+
+        $link = Link::where('slug', $request->slug)->firstOrFail();
+
+        if (!Schema::hasTable('leads')) {
+            return response()->json(['error' => 'Leads table not found'], 500);
+        }
+
+        Lead::create([
+            'document_id'  => $link->document_id,
+            'lead_form_id' => $link->lead_form_id,
+            'name'         => $request->name,
+            'email'        => $request->email,
+        ]);
+
+        return response()->json(['success' => true]);
+    }
+}

--- a/app/Http/Controllers/Vendor/LeadController.php
+++ b/app/Http/Controllers/Vendor/LeadController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use App\Models\Lead;
+use Illuminate\Support\Facades\Auth;
+
+class LeadController extends Controller
+{
+    public function index()
+    {
+        $user = Auth::user();
+        $leads = Lead::whereHas('document', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        })->with('leadForm')->latest()->paginate(10);
+
+        return view('vendor.leads.index', [
+            'leads' => $leads,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Vendor/LeadFormController.php
+++ b/app/Http/Controllers/Vendor/LeadFormController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers\Vendor;
+
+use App\Http\Controllers\Controller;
+use App\Models\LeadForm;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LeadFormController extends Controller
+{
+    public function index()
+    {
+        $forms = LeadForm::where('user_id', Auth::id())->latest()->get();
+
+        return view('vendor.lead_forms.index', [
+            'forms' => $forms,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'name' => 'required|string|max:255',
+        ]);
+
+        LeadForm::create([
+            'user_id' => Auth::id(),
+            'name'    => $data['name'],
+        ]);
+
+        return redirect()->back();
+    }
+}

--- a/app/Models/Document.php
+++ b/app/Models/Document.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Lead;
 
 class Document extends Model
 {
@@ -25,6 +26,11 @@ class Document extends Model
     public function link()
     {
         return $this->hasOne(\App\Models\Link::class, 'document_id');
+    }
+
+    public function leads()
+    {
+        return $this->hasMany(Lead::class);
     }
 
 

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Document;
+
+class Lead extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'document_id',
+        'lead_form_id',
+        'name',
+        'email',
+    ];
+
+    public function document()
+    {
+        return $this->belongsTo(Document::class);
+    }
+
+    public function leadForm()
+    {
+        return $this->belongsTo(LeadForm::class);
+    }
+}

--- a/app/Models/LeadForm.php
+++ b/app/Models/LeadForm.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class LeadForm extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+    ];
+}

--- a/app/Models/Link.php
+++ b/app/Models/Link.php
@@ -15,6 +15,7 @@ class Link extends Model
         'user_id',
         'slug',
         'permissions',
+        'lead_form_id',
         'created_at',
     ];
 
@@ -31,5 +32,10 @@ class Link extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function leadForm()
+    {
+        return $this->belongsTo(LeadForm::class);
     }
 }

--- a/database/migrations/2025_09_01_000002_create_leads_table.php
+++ b/database/migrations/2025_09_01_000002_create_leads_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('leads', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('document_id')->index();
+            $table->string('name');
+            $table->string('email')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('leads');
+    }
+};

--- a/database/migrations/2025_09_08_000000_create_lead_forms_table.php
+++ b/database/migrations/2025_09_08_000000_create_lead_forms_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('lead_forms', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('user_id')->index();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('lead_forms');
+    }
+};

--- a/database/migrations/2025_09_08_000001_add_lead_form_id_to_links_table.php
+++ b/database/migrations/2025_09_08_000001_add_lead_form_id_to_links_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('links', function (Blueprint $table) {
+            $table->unsignedInteger('lead_form_id')->nullable()->index()->after('permissions');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('links', function (Blueprint $table) {
+            $table->dropColumn('lead_form_id');
+        });
+    }
+};

--- a/database/migrations/2025_09_08_000002_add_lead_form_id_to_leads_table.php
+++ b/database/migrations/2025_09_08_000002_add_lead_form_id_to_leads_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            $table->unsignedInteger('lead_form_id')->nullable()->index()->after('document_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            $table->dropColumn('lead_form_id');
+        });
+    }
+};

--- a/resources/views/public/view.blade.php
+++ b/resources/views/public/view.blade.php
@@ -178,6 +178,19 @@
   </main>
 </div>
 
+@if($leadEnabled)
+<div id="leadModal" style="display:none;position:fixed;inset:0;background:rgba(0,0,0,.6);align-items:center;justify-content:center;z-index:1000;">
+  <div style="background:#fff;color:#000;padding:20px;border-radius:8px;width:90%;max-width:400px;">
+    <h5 style="margin-top:0;margin-bottom:15px;">Please leave your details</h5>
+    <form id="leadForm">
+      <div style="margin-bottom:10px;"><input name="name" type="text" placeholder="Name" required style="width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;"></div>
+      <div style="margin-bottom:10px;"><input name="email" type="email" placeholder="Email" style="width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;"></div>
+      <button type="submit" style="width:100%;padding:10px;border:0;background:#111;color:#fff;border-radius:4px;">Submit</button>
+    </form>
+  </div>
+</div>
+@endif
+
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf_viewer.min.js"></script>
 <script>
@@ -417,6 +430,17 @@
     }
   });
   document.addEventListener('contextmenu', function(e){ e.preventDefault(); });
+
+  @if($leadEnabled)
+  var modal = document.getElementById('leadModal');
+  setTimeout(function(){ modal.style.display='flex'; }, 5000);
+  document.getElementById('leadForm').addEventListener('submit', function(e){
+    e.preventDefault();
+    var fd = new FormData(this);
+    fd.append('slug', slug);
+    fetch('/lead', {method:'POST', body: fd}).then(function(){ modal.style.display='none'; });
+  });
+  @endif
 })();
 </script>
 </body>

--- a/resources/views/vendor/files/index.blade.php
+++ b/resources/views/vendor/files/index.blade.php
@@ -204,6 +204,15 @@
             <i class="bi bi-lightning-charge-fill me-1"></i>
             Choose what viewers can do before generating the link.
           </div>
+          <div class="mb-3">
+            <label for="leadFormSelect" class="form-label">Lead form</label>
+            <select id="leadFormSelect" class="form-select">
+              <option value="">None</option>
+              @foreach($leadForms as $form)
+                <option value="{{ $form->id }}">{{ $form->name }}</option>
+              @endforeach
+            </select>
+          </div>
 
           <div class="d-grid gap-3">
             <label class="d-flex align-items-center gap-2">
@@ -493,6 +502,7 @@
       modalEl.dataset.id = btn.dataset.id;
       modalEl._genBtn = btn;
       modalEl._holder = btn.closest('td').querySelector('.link-holder');
+      document.getElementById('leadFormSelect').value='';
       new bootstrap.Modal('#permModal').show();
     }
 
@@ -540,6 +550,8 @@
     fd.append('id', id);
     fd.append('_token', csrf);
     fd.append('permissions', JSON.stringify(perms));
+    const leadId = document.getElementById('leadFormSelect').value;
+    if(leadId) fd.append('lead_form_id', leadId);
 
     const modal = bootstrap.Modal.getInstance('#permModal'); 
     modal.hide();

--- a/resources/views/vendor/files/manage.blade.php
+++ b/resources/views/vendor/files/manage.blade.php
@@ -145,6 +145,15 @@
           <i class="bi bi-lightning-charge-fill me-1"></i>
           Choose what viewers can do before generating the link.
         </div>
+        <div class="mb-3">
+          <label for="leadFormSelect" class="form-label">Lead form</label>
+          <select id="leadFormSelect" class="form-select">
+            <option value="">None</option>
+            @foreach($leadForms as $form)
+              <option value="{{ $form->id }}">{{ $form->name }}</option>
+            @endforeach
+          </select>
+        </div>
         <div class="d-grid gap-3">
           <label class="d-flex align-items-center gap-2">
             <i class="bi bi-download text-secondary"></i>
@@ -295,6 +304,7 @@
       modalEl.dataset.id=id;
       modalEl._genBtn=e.target.closest('.btn-generate');
       modalEl._holder=tr.querySelector('.small-link');
+      document.getElementById('leadFormSelect').value='';
       new bootstrap.Modal('#permModal').show();
       return;
     }
@@ -325,6 +335,8 @@
     const fd=new FormData();
     fd.append('id',id);
     fd.append('permissions',JSON.stringify(perms));
+    const leadId=document.getElementById('leadFormSelect').value;
+    if(leadId) fd.append('lead_form_id',leadId);
     const btn=modalEl._genBtn;
     const holder=modalEl._holder;
     const modal=bootstrap.Modal.getInstance('#permModal');

--- a/resources/views/vendor/files/show.blade.php
+++ b/resources/views/vendor/files/show.blade.php
@@ -19,6 +19,13 @@
     <p><strong>Size:</strong> {{ number_format($doc->size / 1024, 2) }} KB</p>
     <p><strong>Type:</strong> PDF</p>
     <div class="my-3">
+      <label for="leadFormSelect" class="form-label">Lead form</label>
+      <select id="leadFormSelect" class="form-select w-auto mb-2">
+        <option value="">None</option>
+        @foreach($leadForms as $form)
+          <option value="{{ $form->id }}">{{ $form->name }}</option>
+        @endforeach
+      </select>
       <button id="btnGenerate" type="button" class="btn btn-secondary">Generate Link</button>
     </div>
     <div class="input-group mb-3">
@@ -32,13 +39,14 @@
 @push('scripts')
 <script>
   document.getElementById('btnGenerate').addEventListener('click', function(){
+    const lead = document.getElementById('leadFormSelect').value;
     fetch(@json(route('vendor.files.generate')), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-CSRF-TOKEN': @json(csrf_token())
       },
-      body: JSON.stringify({id: {{ $doc->id }}})
+      body: JSON.stringify({id: {{ $doc->id }}, lead_form_id: lead})
     }).then(r => r.json()).then(data => {
       if(data.url){
         document.getElementById('linkInput').value = data.url;

--- a/resources/views/vendor/layouts/partials/sidebar.blade.php
+++ b/resources/views/vendor/layouts/partials/sidebar.blade.php
@@ -27,6 +27,12 @@
     <a class="nav-link {{ request()->routeIs('vendor.analytics.*') ? 'active' : '' }}" href="{{ route('vendor.analytics.index') }}">
       <i class="bi bi-bar-chart"></i> <span>Analytics</span>
     </a>
+    <a class="nav-link {{ request()->routeIs('vendor.leads.index') ? 'active' : '' }}" href="{{ route('vendor.leads.index') }}">
+      <i class="bi bi-person-lines-fill"></i> <span>Leads</span>
+    </a>
+    <a class="nav-link {{ request()->routeIs('vendor.lead_forms.index') ? 'active' : '' }}" href="{{ route('vendor.lead_forms.index') }}">
+      <i class="bi bi-ui-checks-grid"></i> <span>Lead Forms</span>
+    </a>
     <a class="nav-link {{ request()->routeIs('vendor.plan.index') ? 'active' : '' }}" href="{{ route('vendor.plan.index') }}">
       <i class="bi bi-gem"></i> <span>Plan</span>
     </a>

--- a/resources/views/vendor/lead_forms/index.blade.php
+++ b/resources/views/vendor/lead_forms/index.blade.php
@@ -1,0 +1,42 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'Lead Forms')
+
+@section('content')
+<div class="container py-3">
+  <h2 class="mb-3">Lead Forms</h2>
+
+  <form method="post" action="{{ route('vendor.lead_forms.store') }}" class="mb-3">
+    @csrf
+    <div class="input-group">
+      <input type="text" name="name" class="form-control" placeholder="Form name" required>
+      <button class="btn btn-primary" type="submit">Add</button>
+    </div>
+  </form>
+
+  <div class="card">
+    <div class="card-body p-0">
+      <table class="table mb-0">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Created</th>
+          </tr>
+        </thead>
+        <tbody>
+          @forelse($forms as $form)
+            <tr>
+              <td>{{ $form->name }}</td>
+              <td>{{ $form->created_at->format('Y-m-d H:i') }}</td>
+            </tr>
+          @empty
+            <tr>
+              <td colspan="2" class="text-center py-4">No forms yet.</td>
+            </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/vendor/leads/index.blade.php
+++ b/resources/views/vendor/leads/index.blade.php
@@ -1,0 +1,42 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'Leads')
+
+@section('content')
+<div class="container py-3">
+  <h2 class="mb-3">Leads</h2>
+  <div class="card">
+    <div class="card-body p-0">
+      <table class="table mb-0">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Document</th>
+            <th>Form</th>
+            <th>Date</th>
+          </tr>
+        </thead>
+        <tbody>
+          @forelse($leads as $lead)
+            <tr>
+              <td>{{ $lead->name }}</td>
+              <td>{{ $lead->email }}</td>
+              <td>{{ optional($lead->document)->filename }}</td>
+              <td>{{ optional($lead->leadForm)->name }}</td>
+              <td>{{ $lead->created_at->format('Y-m-d H:i') }}</td>
+            </tr>
+          @empty
+            <tr>
+              <td colspan="4" class="text-center py-4">No leads found.</td>
+            </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div class="mt-3">
+    {{ $leads->links() }}
+  </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\Auth\PasswordResetController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\HomeController;
+use App\Http\Controllers\LeadCaptureController;
 use App\Http\Controllers\NewsletterSubscriptionController;
 use App\Http\Controllers\PartnershipsController;
 use App\Http\Controllers\Vendor\AnalyticsController;
@@ -18,6 +19,8 @@ use App\Http\Controllers\Vendor\NotificationController;
 use App\Http\Controllers\Vendor\PasswordController;
 use App\Http\Controllers\Vendor\PlanController;
 use App\Http\Controllers\Vendor\ProfileController;
+use App\Http\Controllers\Vendor\LeadController as VendorLeadController;
+use App\Http\Controllers\Vendor\LeadFormController as VendorLeadFormController;
 use Illuminate\Support\Facades\Route;
 
 /* ------------------------- Guest (auth) ------------------------- */
@@ -96,6 +99,11 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
 
     // Notifications
     Route::get('notifications', [NotificationController::class, 'index'])->name('vendor.notifications.index');
+
+    // Leads
+    Route::get('leads', [VendorLeadController::class, 'index'])->name('vendor.leads.index');
+    Route::get('lead-forms', [VendorLeadFormController::class, 'index'])->name('vendor.lead_forms.index');
+    Route::post('lead-forms', [VendorLeadFormController::class, 'store'])->name('vendor.lead_forms.store');
 });
 
 /* ------------------------- Admin dashboard ------------------------- */
@@ -115,6 +123,11 @@ Route::get('/get-pdf', [DocumentController::class, 'streamBySlug'])->name('publi
 // 🔹 NEW: analytics endpoint used by the viewer JS
 Route::post('/track', [DocumentController::class, 'track'])
     ->name('public.track')
+    ->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+
+// Lead capture
+Route::post('/lead', [LeadCaptureController::class, 'store'])
+    ->name('public.lead.store')
     ->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
 
 /* Optional legacy */


### PR DESCRIPTION
## Summary
- let vendors create lead forms from their dashboard
- allow selecting a lead form when generating a document link
- show the lead capture modal only when a link has an associated form

## Testing
- `composer install` (failed: Script @php artisan package:discover --ansi handling the post-autoload-dump event returned with error code 1)
- `php artisan test` (failed: Symfony\Component\HttpFoundation\Request::create(): Argument #1 ($uri) must be of type string, null given)


------
https://chatgpt.com/codex/tasks/task_e_68b9c5e48ea0832790814b8ffa0f1a57