### PR TITLE
Fix lead capture fetch URL

### DIFF
--- a/resources/views/public/view.blade.php
+++ b/resources/views/public/view.blade.php
@@ -438,7 +438,7 @@
     e.preventDefault();
     var fd = new FormData(this);
     fd.append('slug', slug);
-    fetch('/lead', {method:'POST', body: fd}).then(function(){ modal.style.display='none'; });
+    fetch('{{ route('public.lead.store') }}', {method:'POST', body: fd}).then(function(){ modal.style.display='none'; });
   });
   @endif
 })();


### PR DESCRIPTION
## Summary
- point lead capture form to the correct base URL using the named route

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9cf0ac56883279add3d9e9ef39fa9