### PR TITLE
Exclude lead route from CSRF verification

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware
+{
+    /**
+     * The URIs that should be excluded from CSRF verification.
+     *
+     * @var array<int, string>
+     */
+    protected $except = [
+        'lead',
+    ];
+}
+


### PR DESCRIPTION
## Summary
- prevent 419 Page Expired errors by excluding `/lead` from CSRF checks

## Testing
- `composer test` *(fails: Script @php artisan config:clear --ansi handling the test event returned with error code 255)*
- `php artisan test` *(fails: Symfony\Component\HttpFoundation\Request::create(): Argument #1 ($uri) must be of type string, null given)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d07c7de08327bd29e71eab2d39ea