### PR TITLE
Add drag-and-drop lead form builder

### DIFF
--- a/app/Http/Controllers/Vendor/LeadFormController.php
+++ b/app/Http/Controllers/Vendor/LeadFormController.php
@@ -31,4 +31,28 @@ class LeadFormController extends Controller
 
         return redirect()->back();
     }
+
+    public function edit(LeadForm $lead_form)
+    {
+        abort_if($lead_form->user_id !== Auth::id(), 403);
+
+        return view('vendor.lead_forms.edit', [
+            'form' => $lead_form,
+        ]);
+    }
+
+    public function update(Request $request, LeadForm $lead_form)
+    {
+        abort_if($lead_form->user_id !== Auth::id(), 403);
+
+        $data = $request->validate([
+            'fields' => 'nullable|string',
+        ]);
+
+        $lead_form->update([
+            'fields' => $data['fields'] ? json_decode($data['fields'], true) : null,
+        ]);
+
+        return redirect()->route('vendor.lead_forms.index');
+    }
 }

--- a/app/Models/LeadForm.php
+++ b/app/Models/LeadForm.php
@@ -12,5 +12,10 @@ class LeadForm extends Model
     protected $fillable = [
         'user_id',
         'name',
+        'fields',
+    ];
+
+    protected $casts = [
+        'fields' => 'array',
     ];
 }

--- a/database/migrations/2025_09_08_000003_add_fields_to_lead_forms_table.php
+++ b/database/migrations/2025_09_08_000003_add_fields_to_lead_forms_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('lead_forms', function (Blueprint $table) {
+            $table->json('fields')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('lead_forms', function (Blueprint $table) {
+            $table->dropColumn('fields');
+        });
+    }
+};

--- a/resources/js/lead-form-builder.js
+++ b/resources/js/lead-form-builder.js
@@ -1,0 +1,58 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const palette = document.getElementById('field-palette');
+  const canvas = document.getElementById('builder-canvas');
+  const input = document.getElementById('fields-input');
+
+  let fields = window.existingFields || [];
+
+  function render() {
+    canvas.innerHTML = '';
+    fields.forEach((field, index) => {
+      const wrapper = document.createElement('div');
+      wrapper.className = 'mb-3';
+
+      const label = document.createElement('label');
+      label.textContent = field.label || field.type;
+      wrapper.appendChild(label);
+
+      let el;
+      if (field.type === 'textarea') {
+        el = document.createElement('textarea');
+      } else {
+        el = document.createElement('input');
+        el.type = field.type;
+      }
+      el.className = 'form-control';
+      wrapper.appendChild(el);
+
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'btn btn-sm btn-danger mt-1';
+      remove.textContent = 'Remove';
+      remove.addEventListener('click', () => {
+        fields.splice(index, 1);
+        render();
+      });
+      wrapper.appendChild(remove);
+
+      canvas.appendChild(wrapper);
+    });
+    input.value = JSON.stringify(fields);
+  }
+
+  render();
+
+  palette.querySelectorAll('.draggable-field').forEach(el => {
+    el.addEventListener('dragstart', e => {
+      e.dataTransfer.setData('type', el.dataset.type);
+    });
+  });
+
+  canvas.addEventListener('dragover', e => e.preventDefault());
+  canvas.addEventListener('drop', e => {
+    e.preventDefault();
+    const type = e.dataTransfer.getData('type');
+    fields.push({ type, label: type.charAt(0).toUpperCase() + type.slice(1) });
+    render();
+  });
+});

--- a/resources/views/vendor/lead_forms/edit.blade.php
+++ b/resources/views/vendor/lead_forms/edit.blade.php
@@ -1,0 +1,38 @@
+@extends('vendor.layouts.app')
+
+@section('title', 'Edit Lead Form')
+
+@vite('resources/js/lead-form-builder.js')
+
+@section('content')
+<div class="container py-3">
+  <h2 class="mb-3">Edit Lead Form: {{ $form->name }}</h2>
+
+  <div class="row">
+    <div class="col-md-4">
+      <h5>Fields</h5>
+      <div id="field-palette">
+        <div class="draggable-field btn btn-light w-100 mb-2" draggable="true" data-type="text">Text</div>
+        <div class="draggable-field btn btn-light w-100 mb-2" draggable="true" data-type="email">Email</div>
+        <div class="draggable-field btn btn-light w-100 mb-2" draggable="true" data-type="textarea">Textarea</div>
+      </div>
+    </div>
+    <div class="col-md-8">
+      <h5>Form Preview</h5>
+      <form id="builder-canvas" class="border p-3" style="min-height:200px;"></form>
+    </div>
+  </div>
+
+  <form method="post" action="{{ route('vendor.lead_forms.update', $form) }}" class="mt-3">
+    @csrf
+    @method('put')
+    <input type="hidden" name="fields" id="fields-input">
+    <button class="btn btn-primary" type="submit">Save</button>
+    <a href="{{ route('vendor.lead_forms.index') }}" class="btn btn-secondary">Cancel</a>
+  </form>
+</div>
+
+<script>
+  window.existingFields = @json($form->fields ?? []);
+</script>
+@endsection

--- a/resources/views/vendor/lead_forms/index.blade.php
+++ b/resources/views/vendor/lead_forms/index.blade.php
@@ -21,6 +21,7 @@
           <tr>
             <th>Name</th>
             <th>Created</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -28,10 +29,11 @@
             <tr>
               <td>{{ $form->name }}</td>
               <td>{{ $form->created_at->format('Y-m-d H:i') }}</td>
+              <td><a href="{{ route('vendor.lead_forms.edit', $form) }}" class="btn btn-sm btn-secondary">Edit</a></td>
             </tr>
           @empty
             <tr>
-              <td colspan="2" class="text-center py-4">No forms yet.</td>
+              <td colspan="3" class="text-center py-4">No forms yet.</td>
             </tr>
           @endforelse
         </tbody>

--- a/routes/web.php
+++ b/routes/web.php
@@ -104,6 +104,8 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
     Route::get('leads', [VendorLeadController::class, 'index'])->name('vendor.leads.index');
     Route::get('lead-forms', [VendorLeadFormController::class, 'index'])->name('vendor.lead_forms.index');
     Route::post('lead-forms', [VendorLeadFormController::class, 'store'])->name('vendor.lead_forms.store');
+    Route::get('lead-forms/{lead_form}/edit', [VendorLeadFormController::class, 'edit'])->name('vendor.lead_forms.edit');
+    Route::put('lead-forms/{lead_form}', [VendorLeadFormController::class, 'update'])->name('vendor.lead_forms.update');
 });
 
 /* ------------------------- Admin dashboard ------------------------- */


### PR DESCRIPTION
## Summary
- store lead form field definitions via new `fields` JSON column
- allow vendors to edit forms with drag-and-drop builder UI
- expose edit/update routes and controller actions for saving custom fields

## Testing
- `npm run build`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9d41786d48327a6b9b9be9779a292