### PR TITLE
Fix Vite configuration for lead form builder

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,11 @@ import tailwindcss from '@tailwindcss/vite';
 export default defineConfig({
     plugins: [
         laravel({
-            input: ['resources/css/app.css', 'resources/js/app.js'],
+            input: [
+                'resources/css/app.css',
+                'resources/js/app.js',
+                'resources/js/lead-form-builder.js',
+            ],
             refresh: true,
         }),
         tailwindcss(),


### PR DESCRIPTION
## Summary
- include `resources/js/lead-form-builder.js` in Vite build inputs

## Testing
- `npm run build`
- `composer test` *(fails: file_get_contents(/workspace/onepdf-app-laravel/.env): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d6b871d08327b77eb77fcda076fb