### PR TITLE
Fix Vite asset resolution for lead form builder

### DIFF
--- a/resources/views/vendor/lead_forms/edit.blade.php
+++ b/resources/views/vendor/lead_forms/edit.blade.php
@@ -2,8 +2,6 @@
 
 @section('title', 'Edit Lead Form')
 
-@vite('resources/js/lead-form-builder.js')
-
 @section('content')
 <div class="container py-3">
   <h2 class="mb-3">Edit Lead Form: {{ $form->name }}</h2>
@@ -36,3 +34,7 @@
   window.existingFields = @json($form->fields ?? []);
 </script>
 @endsection
+
+@push('scripts')
+  @vite('resources/js/lead-form-builder.js')
+@endpush


### PR DESCRIPTION
## Summary
- load lead-form-builder JavaScript via Blade script stack so Vite manifest can be found

## Testing
- `npm run build`
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b9d991675483279bc30346efc09902