### PR TITLE
feat: restyle vendor leads page

### DIFF
--- a/app/Http/Controllers/Vendor/LeadController.php
+++ b/app/Http/Controllers/Vendor/LeadController.php
@@ -5,18 +5,37 @@ namespace App\Http\Controllers\Vendor;
 use App\Http\Controllers\Controller;
 use App\Models\Lead;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Request;
 
 class LeadController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
         $user = Auth::user();
-        $leads = Lead::whereHas('document', function ($q) use ($user) {
+
+        $query = Lead::whereHas('document', function ($q) use ($user) {
             $q->where('user_id', $user->id);
-        })->with('leadForm')->latest()->paginate(10);
+        })->with('leadForm')->latest();
+
+        $search = $request->query('search');
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $q->where('name', 'like', "%{$search}%")
+                  ->orWhere('email', 'like', "%{$search}%")
+                  ->orWhereHas('document', function ($dq) use ($search) {
+                      $dq->where('filename', 'like', "%{$search}%");
+                  })
+                  ->orWhereHas('leadForm', function ($fq) use ($search) {
+                      $fq->where('name', 'like', "%{$search}%");
+                  });
+            });
+        }
+
+        $leads = $query->paginate(10)->withQueryString();
 
         return view('vendor.leads.index', [
             'leads' => $leads,
+            'search' => $search,
         ]);
     }
 }

--- a/resources/views/vendor/leads/index.blade.php
+++ b/resources/views/vendor/leads/index.blade.php
@@ -2,19 +2,103 @@
 
 @section('title', 'Leads')
 
+@push('styles')
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --surface:#fff; --bg:#f6f7fb; --text:#0f172a; --muted:#64748b; --line:#eaeef3;
+    --radius:14px; --shadow:0 10px 30px rgba(2,6,23,.06);
+  }
+  *{font-family:"DM Sans",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+  body{background:var(--bg)}
+  .card{border:0;border-radius:var(--radius);box-shadow:var(--shadow)}
+  .card-header{background:#fff;border-bottom:1px solid var(--line);padding:14px 16px}
+
+  /* ===== top-band / breadcrumb ===== */
+  .top-band{
+    background: radial-gradient(1200px 220px at 50% -140px, rgba(59,130,246,.18) 0%, rgba(59,130,246,0) 60%),
+                linear-gradient(180deg,#f6f7fb 0%,#f6f7fb 60%,transparent 100%);
+    border-bottom:1px solid var(--line);
+  }
+  .crumb{display:flex;align-items:center;gap:.5rem;font-size:.95rem;color:#64748b}
+  .crumb a{color:#0f172a;text-decoration:none}
+  .crumb i{opacity:.6}
+
+  /* Toolbar */
+  .leads-toolbar{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+  .leads-left{display:flex;align-items:center;gap:10px;flex:1 1 auto;min-width:260px}
+  .leads-left .folder{font-weight:600;color:var(--text);display:flex;align-items:center;gap:8px}
+  .leads-left .count{display:inline-flex;min-width:26px;height:26px;padding:0 8px;border-radius:999px;background:#f0f2f7;color:#111;align-items:center;justify-content:center;font-size:.85rem;font-weight:600}
+  .search-wrap{position:relative;flex:1 1 420px}
+  .search-wrap i{position:absolute;left:12px;top:50%;transform:translateY(-50%);color:var(--muted)}
+  .search-input{padding-left:36px;border-radius:12px;border:1px solid var(--line);height:42px}
+
+  table.table{margin:0}
+  .table td, .table th{vertical-align:middle}
+  thead th{color:#475569;font-weight:600;border-bottom:1px solid var(--line);background:#fff}
+  tbody td{border-color:var(--line)}
+
+  /* Pagination */
+  .pagination-wrap{display:flex;flex-direction:column;align-items:center;gap:8px}
+  .pager-summary{color:#64748b;font-size:.9rem}
+  .pagination{gap:8px}
+  .pagination .page-link{
+    border:1px solid var(--line);
+    background:#fff;
+    color:#111;
+    border-radius:12px;
+    min-width:42px;height:42px;
+    padding:0 12px;
+    display:flex;align-items:center;justify-content:center;
+    font-weight:700;
+    box-shadow:0 2px 6px rgba(0,0,0,.04);
+  }
+  .pagination .page-item.active .page-link{background:#111;border-color:#111;color:#fff}
+  .pagination .page-item:not(.active):not(.disabled) .page-link:hover{background:#f2f4f7}
+  .pagination .page-item.disabled .page-link{opacity:.45;cursor:not-allowed}
+</style>
+@endpush
+
 @section('content')
+<!-- top-band breadcrumb -->
+<div class="top-band">
+  <div class="container py-3">
+    <div class="d-flex align-items-center justify-content-between">
+      <nav class="crumb">
+        <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <i class="bi bi-chevron-right"></i>
+        <span>Leads</span>
+      </nav>
+    </div>
+  </div>
+</div>
+
 <div class="container py-3">
-  <h2 class="mb-3">Leads</h2>
   <div class="card">
-    <div class="card-body p-0">
-      <table class="table mb-0">
+    <div class="card-header">
+      <div class="leads-toolbar">
+        <div class="leads-left">
+          <div class="folder"><i class="bi bi-people"></i> Leads <span class="count">{{ $leads->total() }}</span></div>
+          <div class="search-wrap">
+            <i class="bi bi-search"></i>
+            <form id="searchForm">
+              <input id="searchInput" name="search" value="{{ $search }}" type="text" class="form-control search-input" placeholder="Search leads...">
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table align-middle mb-0">
         <thead>
           <tr>
             <th>Name</th>
             <th>Email</th>
             <th>Document</th>
             <th>Form</th>
-            <th>Date</th>
+            <th style="width:180px;">Date</th>
           </tr>
         </thead>
         <tbody>
@@ -28,15 +112,30 @@
             </tr>
           @empty
             <tr>
-              <td colspan="4" class="text-center py-4">No leads found.</td>
+              <td colspan="5" class="text-center py-4">No leads found.</td>
             </tr>
           @endforelse
         </tbody>
       </table>
     </div>
   </div>
-  <div class="mt-3">
-    {{ $leads->links() }}
-  </div>
+
+  <nav class="mt-4 pagination-wrap" aria-label="Leads pagination">
+    @if($leads->total())
+      <div class="pager-summary">Showing {{ $leads->firstItem() }}–{{ $leads->lastItem() }} of {{ $leads->total() }}</div>
+    @endif
+    <div>
+      {{ $leads->onEachSide(1)->links('pagination::bootstrap-5') }}
+    </div>
+  </nav>
 </div>
 @endsection
+
+@push('scripts')
+<script>
+document.getElementById('searchInput').addEventListener('input', function(){
+  document.getElementById('searchForm').submit();
+});
+</script>
+@endpush
+


### PR DESCRIPTION
## Summary
- restyle vendor leads list with modern UI and search field
- add server-side filtering for leads by name, email, document, or form

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e049efbc83279881c263b0ae148d