### PR TITLE
Add lead deletion and export options

### DIFF
--- a/app/Http/Controllers/Vendor/LeadController.php
+++ b/app/Http/Controllers/Vendor/LeadController.php
@@ -38,4 +38,59 @@ class LeadController extends Controller
             'search' => $search,
         ]);
     }
+
+    public function destroy(Lead $lead)
+    {
+        $lead->load('document');
+        abort_unless(optional($lead->document)->user_id === Auth::id(), 403);
+        $lead->delete();
+        return redirect()->route('vendor.leads.index')->with('status', 'Lead deleted');
+    }
+
+    public function bulkDestroy(Request $request)
+    {
+        $ids = $request->input('ids', []);
+        if (!is_array($ids) || empty($ids)) {
+            return redirect()->route('vendor.leads.index');
+        }
+
+        $userId = Auth::id();
+        Lead::whereIn('id', $ids)
+            ->whereHas('document', function ($q) use ($userId) {
+                $q->where('user_id', $userId);
+            })
+            ->delete();
+
+        return redirect()->route('vendor.leads.index')->with('status', 'Selected leads deleted');
+    }
+
+    public function export(Request $request)
+    {
+        $user = Auth::user();
+        $leads = Lead::whereHas('document', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        })->with(['document', 'leadForm'])->cursor();
+
+        $headers = [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment; filename="leads.csv"',
+        ];
+
+        $callback = static function () use ($leads) {
+            $handle = fopen('php://output', 'w');
+            fputcsv($handle, ['Name', 'Email', 'Document', 'Form', 'Date']);
+            foreach ($leads as $lead) {
+                fputcsv($handle, [
+                    $lead->name,
+                    $lead->email,
+                    optional($lead->document)->filename,
+                    optional($lead->leadForm)->name,
+                    $lead->created_at,
+                ]);
+            }
+            fclose($handle);
+        };
+
+        return response()->stream($callback, 200, $headers);
+    }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,6 +102,9 @@ Route::prefix('vendor')->middleware('auth')->group(function () {
 
     // Leads
     Route::get('leads', [VendorLeadController::class, 'index'])->name('vendor.leads.index');
+    Route::delete('leads', [VendorLeadController::class, 'bulkDestroy'])->name('vendor.leads.bulkDestroy');
+    Route::delete('leads/{lead}', [VendorLeadController::class, 'destroy'])->name('vendor.leads.destroy');
+    Route::get('leads/export', [VendorLeadController::class, 'export'])->name('vendor.leads.export');
     Route::get('lead-forms', [VendorLeadFormController::class, 'index'])->name('vendor.lead_forms.index');
     Route::post('lead-forms', [VendorLeadFormController::class, 'store'])->name('vendor.lead_forms.store');
     Route::get('lead-forms/{lead_form}/edit', [VendorLeadFormController::class, 'edit'])->name('vendor.lead_forms.edit');


### PR DESCRIPTION
## Summary
- enable single and bulk deletion of vendor leads
- add CSV export route with basic progress bar feedback
- update leads table UI with checkboxes, actions, and progress-driven export

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e2f91d0083279e89d270f93e125a