### PR TITLE
Render dynamic lead forms in public viewer

### DIFF
--- a/app/Http/Controllers/Vendor/DocumentController.php
+++ b/app/Http/Controllers/Vendor/DocumentController.php
@@ -275,7 +275,7 @@ class DocumentController extends Controller
     {
         $slug = (string) $request->query('doc', '');
 
-        $link = Link::where('slug', $slug)->firstOrFail();
+        $link = Link::where('slug', $slug)->with('leadForm')->firstOrFail();
 
         // permissions array (avoid shorthand ?:)
         $perms = [];
@@ -312,6 +312,7 @@ class DocumentController extends Controller
             'downloadUrl' => $downloadUrl,
             'perms'       => $perms,
             'leadEnabled' => !empty($link->lead_form_id),
+            'leadFields'  => $link->leadForm->fields ?? [],
         ]);
     }
 

--- a/resources/views/public/view.blade.php
+++ b/resources/views/public/view.blade.php
@@ -1,5 +1,6 @@
 {{-- resources/views/public/view.blade.php --}}
 @php
+  use Illuminate\Support\Str;
   $allowDownload  = !empty($perms['download']);
   $allowPrint     = !empty($perms['print']);
   $allowAnalytics = !empty($perms['analytics']);
@@ -184,8 +185,33 @@
     <h5 style="margin-top:0;margin-bottom:15px;">Please leave your details</h5>
     <form id="leadForm">
       @csrf
-      <div style="margin-bottom:10px;"><input name="name" type="text" placeholder="Name" required style="width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;"></div>
-      <div style="margin-bottom:10px;"><input name="email" type="email" placeholder="Email" style="width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;"></div>
+      @foreach($leadFields as $field)
+        @php $name = $field['name'] ?? Str::slug($field['label'] ?? 'field', '_'); @endphp
+        <div style="margin-bottom:10px;">
+          @switch($field['type'])
+            @case('textarea')
+              <textarea name="{{ $name }}" placeholder="{{ $field['label'] ?? '' }}" style="width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;"></textarea>
+              @break
+            @case('select')
+              <select name="{{ $name }}" style="width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;">
+                @foreach($field['options'] ?? [] as $opt)
+                  <option value="{{ $opt }}">{{ $opt }}</option>
+                @endforeach
+              </select>
+              @break
+            @case('radio')
+              @foreach($field['options'] ?? [] as $opt)
+                <label style="display:block;margin-bottom:4px;"><input type="radio" name="{{ $name }}" value="{{ $opt }}"> {{ $opt }}</label>
+              @endforeach
+              @break
+            @case('checkbox')
+              <label><input type="checkbox" name="{{ $name }}"> {{ $field['label'] ?? '' }}</label>
+              @break
+            @default
+              <input type="{{ $field['type'] }}" name="{{ $name }}" placeholder="{{ $field['label'] ?? '' }}" style="width:100%;padding:8px;border:1px solid #ccc;border-radius:4px;">
+          @endswitch
+        </div>
+      @endforeach
       <button type="submit" style="width:100%;padding:10px;border:0;background:#111;color:#fff;border-radius:4px;">Submit</button>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- load lead form configuration when serving the public viewer
- generate lead capture fields dynamically based on the selected form

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b9ef07a42483278106b215272196ed