### PR TITLE
fix: allow lead capture without email

### DIFF
--- a/app/Http/Controllers/LeadCaptureController.php
+++ b/app/Http/Controllers/LeadCaptureController.php
@@ -11,6 +11,12 @@ class LeadCaptureController extends Controller
 {
     public function store(Request $request)
     {
+        // Normalize empty email values to null so the email rule does not fail when
+        // the field is left blank on the lead form.
+        $request->merge([
+            'email' => $request->email ?: null,
+        ]);
+
         $request->validate([
             'slug' => 'required|string',
             'name' => 'required|string|max:255',

--- a/tests/Feature/LeadCaptureTest.php
+++ b/tests/Feature/LeadCaptureTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Document;
+use App\Models\Link;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+class LeadCaptureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_lead_can_be_stored_with_blank_email(): void
+    {
+        // Create a user, document and link for the lead capture.
+        $user = User::factory()->create();
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'test.pdf',
+            'filepath' => 'test.pdf',
+            'size' => 100,
+        ]);
+        $link = Link::create([
+            'document_id' => $document->id,
+            'user_id' => $user->id,
+            'slug' => Str::random(10),
+            'permissions' => json_encode([]),
+        ]);
+
+        $response = $this->postJson('/lead', [
+            'slug' => $link->slug,
+            'name' => 'John Doe',
+            'email' => '',
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('leads', [
+            'document_id' => $document->id,
+            'name' => 'John Doe',
+            'email' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow blank emails when capturing leads
- add regression test for capturing leads without email

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f21adff88327a50fa76d24970c3a