### PR TITLE
feat: allow leads without name

### DIFF
--- a/app/Http/Controllers/LeadCaptureController.php
+++ b/app/Http/Controllers/LeadCaptureController.php
@@ -11,15 +11,16 @@ class LeadCaptureController extends Controller
 {
     public function store(Request $request)
     {
-        // Normalize empty email values to null so the email rule does not fail when
-        // the field is left blank on the lead form.
+        // Normalize empty values so validation rules work even when fields
+        // are omitted or left blank on the lead form.
         $request->merge([
             'email' => $request->email ?: null,
+            'name'  => $request->name ?: null,
         ]);
 
         $request->validate([
             'slug' => 'required|string',
-            'name' => 'required|string|max:255',
+            'name' => 'nullable|string|max:255',
             'email' => 'nullable|email|max:255',
         ]);
 
@@ -32,7 +33,7 @@ class LeadCaptureController extends Controller
         Lead::create([
             'document_id'  => $link->document_id,
             'lead_form_id' => $link->lead_form_id,
-            'name'         => $request->name,
+            'name'         => $request->name ?? '',
             'email'        => $request->email,
         ]);
 

--- a/tests/Feature/LeadCaptureTest.php
+++ b/tests/Feature/LeadCaptureTest.php
@@ -43,4 +43,34 @@ class LeadCaptureTest extends TestCase
             'email' => null,
         ]);
     }
+
+    public function test_lead_can_be_stored_without_name(): void
+    {
+        $user = User::factory()->create();
+        $document = Document::create([
+            'user_id' => $user->id,
+            'filename' => 'test.pdf',
+            'filepath' => 'test.pdf',
+            'size' => 100,
+        ]);
+        $link = Link::create([
+            'document_id' => $document->id,
+            'user_id' => $user->id,
+            'slug' => Str::random(10),
+            'permissions' => json_encode([]),
+        ]);
+
+        $response = $this->postJson('/lead', [
+            'slug' => $link->slug,
+            'name' => '',
+            'email' => 'john@example.com',
+        ]);
+
+        $response->assertOk();
+        $this->assertDatabaseHas('leads', [
+            'document_id' => $document->id,
+            'name' => '',
+            'email' => 'john@example.com',
+        ]);
+    }
 }


### PR DESCRIPTION
## Summary
- allow lead capture when name is omitted
- test lead storage without a name

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f51f231c8327b28995c1b84908be