### PR TITLE
Rename PDFOneLink references to OneLinkPDF

### DIFF
--- a/core-php/assets/new_index.html
+++ b/core-php/assets/new_index.html
@@ -4,20 +4,20 @@
   <!-- Basic -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>PDFOneLink — Secure PDF Sharing & Analytics in One Link</title>
-  <meta name="description" content="Upload PDFs, share with a single secure link, control permissions, and track opens with analytics. Embed anywhere. Try PDFOneLink for free.">
-  <link rel="canonical" href="https://pdfonelink.com/">
+  <title>OneLinkPDF — Secure PDF Sharing & Analytics in One Link</title>
+  <meta name="description" content="Upload PDFs, share with a single secure link, control permissions, and track opens with analytics. Embed anywhere. Try OneLinkPDF for free.">
+  <link rel="canonical" href="https://onelinkpdf.com/">
 
   <!-- Open Graph / Twitter -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="PDFOneLink — Secure PDF Sharing & Analytics in One Link">
+  <meta property="og:title" content="OneLinkPDF — Secure PDF Sharing & Analytics in One Link">
   <meta property="og:description" content="Upload, share, protect and track PDFs in one powerful link.">
-  <meta property="og:url" content="https://pdfonelink.com/">
-  <meta property="og:image" content="https://pdfonelink.com/og-image.jpg">
+  <meta property="og:url" content="https://onelinkpdf.com/">
+  <meta property="og:image" content="https://onelinkpdf.com/og-image.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="PDFOneLink — Secure PDF Sharing & Analytics in One Link">
+  <meta name="twitter:title" content="OneLinkPDF — Secure PDF Sharing & Analytics in One Link">
   <meta name="twitter:description" content="Upload, share, protect and track PDFs in one powerful link.">
-  <meta name="twitter:image" content="https://pdfonelink.com/og-image.jpg">
+  <meta name="twitter:image" content="https://onelinkpdf.com/og-image.jpg">
 
   <!-- Favicon -->
   <link rel="apple-touch-icon" sizes="180x180" href="favicon_io/apple-touch-icon.png">
@@ -829,10 +829,10 @@
   {
     "@context":"https://schema.org",
     "@type":"SoftwareApplication",
-    "name":"PDFOneLink",
+    "name":"OneLinkPDF",
     "applicationCategory":"BusinessApplication",
     "operatingSystem":"Web",
-    "url":"https://pdfonelink.com/",
+    "url":"https://onelinkpdf.com/",
     "description":"Secure PDF upload, sharing, permission control, and analytics — all in one link.",
     "offers":{
       "@type":"AggregateOffer",
@@ -849,7 +849,7 @@
     "@context":"https://schema.org",
     "@type":"FAQPage",
     "mainEntity":[
-      {"@type":"Question","name":"Can I track who opened my PDF?","acceptedAnswer":{"@type":"Answer","text":"Yes. PDFOneLink captures open events, approximate location, device, referrer, and time spent per page."}},
+      {"@type":"Question","name":"Can I track who opened my PDF?","acceptedAnswer":{"@type":"Answer","text":"Yes. OneLinkPDF captures open events, approximate location, device, referrer, and time spent per page."}},
       {"@type":"Question","name":"Can I disable download or print?","acceptedAnswer":{"@type":"Answer","text":"Yes. You can set view-only, disable download/print, add watermarks and expiry to protect your PDFs."}},
       {"@type":"Question","name":"Can I embed the viewer on my website?","acceptedAnswer":{"@type":"Answer","text":"Yes. One iframe snippet lets you embed a secure viewer anywhere."}},
       {"@type":"Question","name":"Do links expire?","acceptedAnswer":{"@type":"Answer","text":"You can set expiry, revoke access anytime, or issue time-limited tokens."}}
@@ -863,7 +863,7 @@
   <nav class="navbar navbar-expand-lg sticky-top">
     <div class="container">
       <a class="navbar-brand" href="#">
-        <i class="bi bi-file-earmark-pdf"></i>PDFOneLink
+        <i class="bi bi-file-earmark-pdf"></i>OneLinkPDF
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav" aria-controls="nav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -911,7 +911,7 @@
               <button class="btn btn-sm btn-outline-light" id="copySnippet"><i class="bi bi-clipboard"></i> Copy</button>
             </div>
 <pre><code id="snippet">&lt;iframe
-  src="https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN"
+  src="https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN"
   width="100%" height="600"
   style="border:none;border-radius:12px;"
   allow="clipboard-write"&gt;&lt;/iframe&gt;</code></pre>
@@ -1025,7 +1025,7 @@
     <div class="container demo-container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Live Embed Demo</h2>
-        <p class="section-subtitle">See how PDFOneLink works with this interactive demo</p>
+        <p class="section-subtitle">See how OneLinkPDF works with this interactive demo</p>
       </div>
       
       <div class="row g-5 align-items-center">
@@ -1038,7 +1038,7 @@
                   <span class="bg-warning rounded-circle d-inline-block mx-2" style="width: 12px; height: 12px;"></span>
                   <span class="bg-success rounded-circle d-inline-block" style="width: 12px; height: 12px;"></span>
                 </div>
-                <div class="text-muted small">https://pdfonelink.com/view?doc=DEMO_TOKEN</div>
+                <div class="text-muted small">https://onelinkpdf.com/view?doc=DEMO_TOKEN</div>
               </div>
               <div class="dropdown">
                 <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
@@ -1052,7 +1052,7 @@
             </div>
             
             <div class="demo-browser">
-              <iframe src="https://pdfonelink.com/view?doc=DEMO_TOKEN" title="PDFOneLink Demo Viewer" allow="clipboard-write"></iframe>
+              <iframe src="https://onelinkpdf.com/view?doc=DEMO_TOKEN" title="OneLinkPDF Demo Viewer" allow="clipboard-write"></iframe>
             </div>
             
             <div class="demo-controls">
@@ -1213,7 +1213,7 @@
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Frequently asked questions</h2>
-        <p class="section-subtitle">Everything you need to know about PDFOneLink.</p>
+        <p class="section-subtitle">Everything you need to know about OneLinkPDF.</p>
       </div>
       <div class="row g-4">
         <div class="col-lg-6">
@@ -1260,7 +1260,7 @@
     <div class="container">
       <div class="row g-5">
         <div class="col-md-6 col-lg-4">
-          <h5 class="mb-4"><i class="bi bi-file-earmark-pdf me-2"></i>PDFOneLink</h5>
+          <h5 class="mb-4"><i class="bi bi-file-earmark-pdf me-2"></i>OneLinkPDF</h5>
           <p class="mb-4">Secure PDF upload, sharing, permissions, and analytics — all in one link.</p>
           
           <div class="social-links">
@@ -1308,7 +1308,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p class="copyright">© <span id="y"></span> PDFOneLink. All rights reserved.</p>
+        <p class="copyright">© <span id="y"></span> OneLinkPDF. All rights reserved.</p>
         <div class="legal-links">
           <a href="/privacy">Privacy Policy</a>
           <span class="divider">•</span>

--- a/core-php/contact.php
+++ b/core-php/contact.php
@@ -53,7 +53,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 /* --------- Page meta + header --------- */
-$page_title = 'Contact Us - PDFOneLink';
+$page_title = 'Contact Us - OneLinkPDF';
 $page_css   = 'assets/webapp/css/contact.css';
 $page_js    = ''; // we’ll inline JS below for simplicity
 include 'include/header.php';
@@ -73,7 +73,7 @@ include 'include/header.php';
     <div class="row justify-content-center">
       <div class="col-lg-8 text-center">
         <h1 class="display-5 fw-bold mb-3">Get in Touch</h1>
-        <p class="lead text-muted mb-4">We'd love to hear from you. Our team is always ready to help with any questions about PDFOneLink.</p>
+        <p class="lead text-muted mb-4">We'd love to hear from you. Our team is always ready to help with any questions about OneLinkPDF.</p>
       </div>
     </div>
   </div>
@@ -153,8 +153,8 @@ include 'include/header.php';
             <div class="contact-icon"><i class="bi bi-envelope"></i></div>
             <div>
               <h5>Email Us</h5>
-              <p class="text-muted mb-0">support@pdfonelink.com</p>
-              <p class="text-muted">sales@pdfonelink.com</p>
+              <p class="text-muted mb-0">support@onelinkpdf.com</p>
+              <p class="text-muted">sales@onelinkpdf.com</p>
             </div>
           </div>
 
@@ -222,11 +222,11 @@ include 'include/header.php';
         </div>
         <div class="faq-item">
           <h6 class="faq-question"><i class="bi bi-question-circle"></i>How can I request a feature?</h6>
-          <p class="text-muted mb-0">We welcome feature requests! Please email us at feedback@pdfonelink.com with your suggestions. Our product team reviews all requests regularly.</p>
+          <p class="text-muted mb-0">We welcome feature requests! Please email us at feedback@onelinkpdf.com with your suggestions. Our product team reviews all requests regularly.</p>
         </div>
         <div class="faq-item">
           <h6 class="faq-question"><i class="bi bi-question-circle"></i>Do you have an affiliate program?</h6>
-          <p class="text-muted mb-0">Yes, we have an affiliate program that offers commissions for referrals. Contact partnerships@pdfonelink.com for more details.</p>
+          <p class="text-muted mb-0">Yes, we have an affiliate program that offers commissions for referrals. Contact partnerships@onelinkpdf.com for more details.</p>
         </div>
       </div>
     </div>

--- a/core-php/features.php
+++ b/core-php/features.php
@@ -1,5 +1,5 @@
 <?php
-$page_title = 'Features - PDFOneLink';
+$page_title = 'Features - OneLinkPDF';
 $page_css = 'assets/webapp/css/features.css';
 $page_js = 'assets/webapp/js/features.js';
 include 'include/header.php';
@@ -133,7 +133,7 @@ include 'include/header.php';
         <div class="container">
             <div class="text-center mb-5">
                 <h2 class="section-title centered">See It In Action</h2>
-                <p class="section-subtitle">Explore how PDFOneLink works with our interactive demo</p>
+                <p class="section-subtitle">Explore how OneLinkPDF works with our interactive demo</p>
             </div>
             
             <div class="demo-card">
@@ -223,7 +223,7 @@ include 'include/header.php';
                                 <div class="border rounded-3 p-4 bg-white">
                                     <h5 class="mb-3">Share Document</h5>
                                     <div class="input-group mb-3">
-                                        <input type="text" class="form-control" value="https://pdfonelink.com/doc/abc123" readonly>
+                                        <input type="text" class="form-control" value="https://onelinkpdf.com/doc/abc123" readonly>
                                         <button class="btn btn-outline-secondary" type="button"><i class="bi bi-clipboard"></i></button>
                                     </div>
                                     <div class="form-check form-switch mb-2">
@@ -307,7 +307,7 @@ include 'include/header.php';
         <div class="container">
             <div class="text-center mb-5">
                 <h2 class="section-title centered">Perfect For Every Use Case</h2>
-                <p class="section-subtitle">PDFOneLink helps professionals across industries share documents securely</p>
+                <p class="section-subtitle">OneLinkPDF helps professionals across industries share documents securely</p>
             </div>
             
             <div class="row g-4">
@@ -359,7 +359,7 @@ include 'include/header.php';
         <div class="container">
             <div class="text-center mb-5">
                 <h2 class="section-title centered">Works With Your Tools</h2>
-                <p class="section-subtitle">PDFOneLink integrates seamlessly with the platforms you already use</p>
+                <p class="section-subtitle">OneLinkPDF integrates seamlessly with the platforms you already use</p>
             </div>
             
             <div class="d-flex flex-wrap justify-content-center align-items-center">
@@ -382,7 +382,7 @@ include 'include/header.php';
         <div class="container">
             <div class="row justify-content-center">
                 <div class="col-lg-8 text-center">
-                    <h2 class="mb-4">Ready to try PDFOneLink?</h2>
+                    <h2 class="mb-4">Ready to try OneLinkPDF?</h2>
                     <p class="text-muted mb-4">Start sharing your PDFs securely today. No credit card required.</p>
                     <div class="d-flex justify-content-center gap-3 flex-wrap">
                         <a href="registration" class="btn btn-brand btn-lg">Get Started for Free</a>

--- a/core-php/how-it-works.php
+++ b/core-php/how-it-works.php
@@ -1,5 +1,5 @@
 <?php
-$page_title = 'How It Works - PDFOneLink';
+$page_title = 'How It Works - OneLinkPDF';
 $page_css = 'assets/webapp/css/index.css';
 $page_js = '';
 include 'include/header.php';
@@ -9,7 +9,7 @@ include 'include/header.php';
     <div class="container position-relative">
         <div class="row justify-content-center">
             <div class="col-lg-8 text-center">
-                <h1 class="display-5 fw-bold mb-3">How PDFOneLink Works</h1>
+                <h1 class="display-5 fw-bold mb-3">How OneLinkPDF Works</h1>
                 <p class="lead text-muted mb-4">Set up in minutes — upload, share, and track your PDFs with ease.</p>
             </div>
         </div>
@@ -68,7 +68,7 @@ include 'include/header.php';
             <div class="col-lg-6">
                 <div class="detail-card">
                     <h3 class="mb-4">Step 1: Account Creation & Setup</h3>
-                    <p>Getting started with PDFOneLink is designed to be quick and straightforward:</p>
+                    <p>Getting started with OneLinkPDF is designed to be quick and straightforward:</p>
                     <ul class="list-unstyled">
                         <li class="mb-3"><i class="bi bi-check-circle-fill text-success me-2"></i> <strong>Sign up</strong> with your email address or social account</li>
                         <li class="mb-3"><i class="bi bi-check-circle-fill text-success me-2"></i> <strong>Verify your email</strong> to activate your account</li>

--- a/core-php/include/footer.php
+++ b/core-php/include/footer.php
@@ -2,7 +2,7 @@
     <div class="container">
       <div class="row g-5">
         <div class="col-md-6 col-lg-4">
-          <h5 class="mb-4"><i class="bi bi-file-earmark-pdf me-2"></i>PDFOneLink</h5>
+          <h5 class="mb-4"><i class="bi bi-file-earmark-pdf me-2"></i>OneLinkPDF</h5>
           <p class="mb-4">Secure PDF upload, sharing, permissions, and analytics — all in one link.</p>
 
           <div class="social-links">
@@ -41,7 +41,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p class="copyright">© <span id="y"></span> PDFOneLink. All rights reserved.</p>
+        <p class="copyright">© <span id="y"></span> OneLinkPDF. All rights reserved.</p>
         <div class="legal-links">
           <a href="privacy.php">Privacy Policy</a>
           <span class="divider">•</span>

--- a/core-php/include/header.php
+++ b/core-php/include/header.php
@@ -9,7 +9,7 @@ $current_page = basename($_SERVER['SCRIPT_NAME']);
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <title><?= isset($page_title) ? $page_title : 'PDFOneLink'; ?></title>
+    <title><?= isset($page_title) ? $page_title : 'OneLinkPDF'; ?></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap" rel="stylesheet">
@@ -27,7 +27,7 @@ $current_page = basename($_SERVER['SCRIPT_NAME']);
 
 <nav class="navbar navbar-expand-lg sticky-top">
   <div class="container">
-    <a class="navbar-brand" href="<?= $web_base_url ?>"><i class="bi bi-file-earmark-pdf"></i>PDFOneLink</a>
+    <a class="navbar-brand" href="<?= $web_base_url ?>"><i class="bi bi-file-earmark-pdf"></i>OneLinkPDF</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav" aria-controls="nav" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/core-php/index.php
+++ b/core-php/index.php
@@ -1,5 +1,5 @@
 <?php
-$page_title = 'PDFOneLink — Secure PDF Sharing & Analytics in One Link';
+$page_title = 'OneLinkPDF — Secure PDF Sharing & Analytics in One Link';
 $page_css = '';
 $page_js = 'assets/webapp/js/index.js';
 include 'include/header.php';
@@ -34,7 +34,7 @@ include 'include/header.php';
               <button class="btn btn-sm btn-outline-light" id="copySnippet"><i class="bi bi-clipboard"></i> Copy</button>
             </div>
 <pre><code id="snippet">&lt;iframe
-  src="https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN"
+  src="https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN"
   width="100%" height="600"
   style="border:none;border-radius:12px;"
   allow="clipboard-write"&gt;&lt;/iframe&gt;</code></pre>
@@ -148,7 +148,7 @@ include 'include/header.php';
     <div class="container demo-container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Live Embed Demo</h2>
-        <p class="section-subtitle">See how PDFOneLink works with this interactive demo</p>
+        <p class="section-subtitle">See how OneLinkPDF works with this interactive demo</p>
       </div>
       
       <div class="row g-5 align-items-center">
@@ -161,7 +161,7 @@ include 'include/header.php';
                   <span class="bg-warning rounded-circle d-inline-block mx-2" style="width: 12px; height: 12px;"></span>
                   <span class="bg-success rounded-circle d-inline-block" style="width: 12px; height: 12px;"></span>
                 </div>
-                <div class="text-muted small">https://pdfonelink.com/view?doc=DEMO_TOKEN</div>
+                <div class="text-muted small">https://onelinkpdf.com/view?doc=DEMO_TOKEN</div>
               </div>
               <div class="dropdown">
                 <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
@@ -175,7 +175,7 @@ include 'include/header.php';
             </div>
             
             <div class="demo-browser">
-              <iframe src="https://pdfonelink.com/view?doc=DEMO_TOKEN" title="PDFOneLink Demo Viewer" allow="clipboard-write"></iframe>
+              <iframe src="https://onelinkpdf.com/view?doc=DEMO_TOKEN" title="OneLinkPDF Demo Viewer" allow="clipboard-write"></iframe>
             </div>
             
             <div class="demo-controls">
@@ -336,7 +336,7 @@ include 'include/header.php';
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Frequently asked questions</h2>
-        <p class="section-subtitle">Everything you need to know about PDFOneLink.</p>
+        <p class="section-subtitle">Everything you need to know about OneLinkPDF.</p>
       </div>
       <div class="row g-4">
         <div class="col-lg-6">

--- a/core-php/pricing.php
+++ b/core-php/pricing.php
@@ -1,5 +1,5 @@
 <?php
-$page_title = 'Pricing - PDFOneLink';
+$page_title = 'Pricing - OneLinkPDF';
 $page_css = 'assets/webapp/css/pricing.css';
 include 'include/header.php';
 ?>
@@ -184,14 +184,14 @@ include 'include/header.php';
         <div class="container">
             <div class="text-center mb-5">
                 <h2 class="section-title centered">Loved by Professionals</h2>
-                <p class="section-subtitle">See what our customers are saying about PDFOneLink</p>
+                <p class="section-subtitle">See what our customers are saying about OneLinkPDF</p>
             </div>
             
             <div class="row g-4">
                 <div class="col-md-6 col-lg-4">
                     <div class="testimonial-card">
                         <div class="testimonial-text">
-                            <p>PDFOneLink has transformed how we share sensitive documents with clients. The analytics help us understand engagement, and the security features give us peace of mind.</p>
+                            <p>OneLinkPDF has transformed how we share sensitive documents with clients. The analytics help us understand engagement, and the security features give us peace of mind.</p>
                         </div>
                         <div class="testimonial-author">
                             <div class="testimonial-avatar">SA</div>
@@ -221,7 +221,7 @@ include 'include/header.php';
                 <div class="col-md-6 col-lg-4">
                     <div class="testimonial-card">
                         <div class="testimonial-text">
-                            <p>We switched to PDFOneLink from another service and couldn't be happier. The embed features work seamlessly on our website, and our clients find the viewer intuitive to use.</p>
+                            <p>We switched to OneLinkPDF from another service and couldn't be happier. The embed features work seamlessly on our website, and our clients find the viewer intuitive to use.</p>
                         </div>
                         <div class="testimonial-author">
                             <div class="testimonial-avatar">ER</div>
@@ -290,7 +290,7 @@ include 'include/header.php';
             <div class="row justify-content-center">
                 <div class="col-lg-8 text-center">
                     <h2 class="mb-4">Ready to get started?</h2>
-                    <p class="text-muted mb-4">Join thousands of professionals who trust PDFOneLink with their document sharing needs.</p>
+                    <p class="text-muted mb-4">Join thousands of professionals who trust OneLinkPDF with their document sharing needs.</p>
                     <div class="d-flex justify-content-center gap-3 flex-wrap">
                         <a href="register" class="btn btn-brand btn-lg">Start free trial</a>
                         <a href="contact" class="btn btn-ghost btn-lg">Contact sales</a>

--- a/core-php/privacy.php
+++ b/core-php/privacy.php
@@ -1,5 +1,5 @@
 <?php
-$page_title = 'Privacy Policy - PDFOneLink';
+$page_title = 'Privacy Policy - OneLinkPDF';
 include 'include/header.php';
 ?>
 
@@ -7,8 +7,8 @@ include 'include/header.php';
   <div class="container">
     <h1 class="section-title centered">Privacy Policy</h1>
     <p class="section-subtitle">Your privacy is important to us.</p>
-    <p>This Privacy Policy explains how PDFOneLink collects, uses, and protects your information when you use our services.</p>
-    <p>By using PDFOneLink, you agree to the practices described here. We only collect information necessary to deliver and improve our services, and we never sell your data.</p>
+    <p>This Privacy Policy explains how OneLinkPDF collects, uses, and protects your information when you use our services.</p>
+    <p>By using OneLinkPDF, you agree to the practices described here. We only collect information necessary to deliver and improve our services, and we never sell your data.</p>
     <p>If you have any questions about this policy, please <a href="/contact">contact us</a>.</p>
   </div>
 </section>

--- a/core-php/terms.php
+++ b/core-php/terms.php
@@ -1,5 +1,5 @@
 <?php
-$page_title = 'Terms of Service - PDFOneLink';
+$page_title = 'Terms of Service - OneLinkPDF';
 include 'include/header.php';
 ?>
 
@@ -7,9 +7,9 @@ include 'include/header.php';
   <div class="container">
     <h1 class="section-title centered">Terms of Service</h1>
     <p class="section-subtitle">Please read these terms carefully.</p>
-    <p>By accessing or using PDFOneLink, you agree to the following terms and conditions governing your use of our website and services.</p>
+    <p>By accessing or using OneLinkPDF, you agree to the following terms and conditions governing your use of our website and services.</p>
     <p>We may update these terms from time to time. Continued use of the service constitutes acceptance of the revised terms.</p>
-    <p>If you do not agree with these terms, please discontinue using PDFOneLink.</p>
+    <p>If you do not agree with these terms, please discontinue using OneLinkPDF.</p>
   </div>
 </section>
 

--- a/core-php/vendor_dashboard/includes/sidebar.php
+++ b/core-php/vendor_dashboard/includes/sidebar.php
@@ -32,7 +32,7 @@ $menu = [
         <div class="sidebar-brand-icon rotate-n-15">
             <i class="bi bi-file-earmark-pdf"></i>
         </div>
-        <div class="sidebar-brand-text mx-3">PDFOneLink</div>
+        <div class="sidebar-brand-text mx-3">OneLinkPDF</div>
     </a>
     <?php foreach ($menu as $item): ?>
         <?php if (isset($item['divider'])): ?>

--- a/public/assets/new_index.html
+++ b/public/assets/new_index.html
@@ -4,20 +4,20 @@
   <!-- Basic -->
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>PDFOneLink — Secure PDF Sharing & Analytics in One Link</title>
-  <meta name="description" content="Upload PDFs, share with a single secure link, control permissions, and track opens with analytics. Embed anywhere. Try PDFOneLink for free.">
-  <link rel="canonical" href="https://pdfonelink.com/">
+  <title>OneLinkPDF — Secure PDF Sharing & Analytics in One Link</title>
+  <meta name="description" content="Upload PDFs, share with a single secure link, control permissions, and track opens with analytics. Embed anywhere. Try OneLinkPDF for free.">
+  <link rel="canonical" href="https://onelinkpdf.com/">
 
   <!-- Open Graph / Twitter -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="PDFOneLink — Secure PDF Sharing & Analytics in One Link">
+  <meta property="og:title" content="OneLinkPDF — Secure PDF Sharing & Analytics in One Link">
   <meta property="og:description" content="Upload, share, protect and track PDFs in one powerful link.">
-  <meta property="og:url" content="https://pdfonelink.com/">
-  <meta property="og:image" content="https://pdfonelink.com/og-image.jpg">
+  <meta property="og:url" content="https://onelinkpdf.com/">
+  <meta property="og:image" content="https://onelinkpdf.com/og-image.jpg">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="PDFOneLink — Secure PDF Sharing & Analytics in One Link">
+  <meta name="twitter:title" content="OneLinkPDF — Secure PDF Sharing & Analytics in One Link">
   <meta name="twitter:description" content="Upload, share, protect and track PDFs in one powerful link.">
-  <meta name="twitter:image" content="https://pdfonelink.com/og-image.jpg">
+  <meta name="twitter:image" content="https://onelinkpdf.com/og-image.jpg">
 
   <!-- Favicon -->
   <link rel="apple-touch-icon" sizes="180x180" href="favicon_io/apple-touch-icon.png">
@@ -829,10 +829,10 @@
   {
     "@context":"https://schema.org",
     "@type":"SoftwareApplication",
-    "name":"PDFOneLink",
+    "name":"OneLinkPDF",
     "applicationCategory":"BusinessApplication",
     "operatingSystem":"Web",
-    "url":"https://pdfonelink.com/",
+    "url":"https://onelinkpdf.com/",
     "description":"Secure PDF upload, sharing, permission control, and analytics — all in one link.",
     "offers":{
       "@type":"AggregateOffer",
@@ -849,7 +849,7 @@
     "@context":"https://schema.org",
     "@type":"FAQPage",
     "mainEntity":[
-      {"@type":"Question","name":"Can I track who opened my PDF?","acceptedAnswer":{"@type":"Answer","text":"Yes. PDFOneLink captures open events, approximate location, device, referrer, and time spent per page."}},
+      {"@type":"Question","name":"Can I track who opened my PDF?","acceptedAnswer":{"@type":"Answer","text":"Yes. OneLinkPDF captures open events, approximate location, device, referrer, and time spent per page."}},
       {"@type":"Question","name":"Can I disable download or print?","acceptedAnswer":{"@type":"Answer","text":"Yes. You can set view-only, disable download/print, add watermarks and expiry to protect your PDFs."}},
       {"@type":"Question","name":"Can I embed the viewer on my website?","acceptedAnswer":{"@type":"Answer","text":"Yes. One iframe snippet lets you embed a secure viewer anywhere."}},
       {"@type":"Question","name":"Do links expire?","acceptedAnswer":{"@type":"Answer","text":"You can set expiry, revoke access anytime, or issue time-limited tokens."}}
@@ -863,7 +863,7 @@
   <nav class="navbar navbar-expand-lg sticky-top">
     <div class="container">
       <a class="navbar-brand" href="#">
-        <i class="bi bi-file-earmark-pdf"></i>PDFOneLink
+        <i class="bi bi-file-earmark-pdf"></i>OneLinkPDF
       </a>
       <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav" aria-controls="nav" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
@@ -911,7 +911,7 @@
               <button class="btn btn-sm btn-outline-light" id="copySnippet"><i class="bi bi-clipboard"></i> Copy</button>
             </div>
 <pre><code id="snippet">&lt;iframe
-  src="https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN"
+  src="https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN"
   width="100%" height="600"
   style="border:none;border-radius:12px;"
   allow="clipboard-write"&gt;&lt;/iframe&gt;</code></pre>
@@ -1025,7 +1025,7 @@
     <div class="container demo-container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Live Embed Demo</h2>
-        <p class="section-subtitle">See how PDFOneLink works with this interactive demo</p>
+        <p class="section-subtitle">See how OneLinkPDF works with this interactive demo</p>
       </div>
       
       <div class="row g-5 align-items-center">
@@ -1038,7 +1038,7 @@
                   <span class="bg-warning rounded-circle d-inline-block mx-2" style="width: 12px; height: 12px;"></span>
                   <span class="bg-success rounded-circle d-inline-block" style="width: 12px; height: 12px;"></span>
                 </div>
-                <div class="text-muted small">https://pdfonelink.com/view?doc=DEMO_TOKEN</div>
+                <div class="text-muted small">https://onelinkpdf.com/view?doc=DEMO_TOKEN</div>
               </div>
               <div class="dropdown">
                 <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
@@ -1052,7 +1052,7 @@
             </div>
             
             <div class="demo-browser">
-              <iframe src="https://pdfonelink.com/view?doc=DEMO_TOKEN" title="PDFOneLink Demo Viewer" allow="clipboard-write"></iframe>
+              <iframe src="https://onelinkpdf.com/view?doc=DEMO_TOKEN" title="OneLinkPDF Demo Viewer" allow="clipboard-write"></iframe>
             </div>
             
             <div class="demo-controls">
@@ -1213,7 +1213,7 @@
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Frequently asked questions</h2>
-        <p class="section-subtitle">Everything you need to know about PDFOneLink.</p>
+        <p class="section-subtitle">Everything you need to know about OneLinkPDF.</p>
       </div>
       <div class="row g-4">
         <div class="col-lg-6">
@@ -1260,7 +1260,7 @@
     <div class="container">
       <div class="row g-5">
         <div class="col-md-6 col-lg-4">
-          <h5 class="mb-4"><i class="bi bi-file-earmark-pdf me-2"></i>PDFOneLink</h5>
+          <h5 class="mb-4"><i class="bi bi-file-earmark-pdf me-2"></i>OneLinkPDF</h5>
           <p class="mb-4">Secure PDF upload, sharing, permissions, and analytics — all in one link.</p>
           
           <div class="social-links">
@@ -1308,7 +1308,7 @@
         </div>
       </div>
       <div class="footer-bottom">
-        <p class="copyright">© <span id="y"></span> PDFOneLink. All rights reserved.</p>
+        <p class="copyright">© <span id="y"></span> OneLinkPDF. All rights reserved.</p>
         <div class="legal-links">
           <a href="/privacy">Privacy Policy</a>
           <span class="divider">•</span>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -114,7 +114,7 @@
       <div class="col-md-12">
         <div class="card card-container">
           <h3 class="text-center mb-1">Create Account</h3>
-          <p class="text-center text-muted mb-4">Join PDFOneLink in minutes.</p>
+          <p class="text-center text-muted mb-4">Join OneLinkPDF in minutes.</p>
 
           <form id="registerForm" novalidate>
             @csrf

--- a/resources/views/contact.blade.php
+++ b/resources/views/contact.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Contact Us - PDFOneLink')
+@section('title', 'Contact Us - OneLinkPDF')
 
 
 @section('content')
@@ -10,7 +10,7 @@
       <div class="row justify-content-center">
         <div class="col-lg-8 text-center">
           <h1 class="display-5 fw-bold mb-3">Get in Touch</h1>
-          <p class="lead text-muted mb-4">We'd love to hear from you. Our team is always ready to help with any questions about PDFOneLink.</p>
+          <p class="lead text-muted mb-4">We'd love to hear from you. Our team is always ready to help with any questions about OneLinkPDF.</p>
         </div>
       </div>
     </div>
@@ -106,8 +106,8 @@
               <div class="contact-icon"><i class="bi bi-envelope"></i></div>
               <div>
                 <h5>Email Us</h5>
-                <p class="text-muted mb-0">support@pdfonelink.com</p>
-                <p class="text-muted">sales@pdfonelink.com</p>
+                <p class="text-muted mb-0">support@onelinkpdf.com</p>
+                <p class="text-muted">sales@onelinkpdf.com</p>
               </div>
             </div>
 

--- a/resources/views/docs.blade.php
+++ b/resources/views/docs.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Documentation - PDFOneLink')
+@section('title', 'Documentation - OneLinkPDF')
 
 @section('content')
 <section class="section">

--- a/resources/views/features.blade.php
+++ b/resources/views/features.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Features - PDFOneLink')
+@section('title', 'Features - OneLinkPDF')
 
 
 @section('content')
@@ -121,7 +121,7 @@
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">See It In Action</h2>
-        <p class="section-subtitle">Explore how PDFOneLink works with our interactive demo</p>
+        <p class="section-subtitle">Explore how OneLinkPDF works with our interactive demo</p>
       </div>
 
       <div class="demo-card">
@@ -214,7 +214,7 @@
                 <div class="border rounded-3 p-4 bg-white">
                   <h5 class="mb-3">Share Document</h5>
                   <div class="input-group mb-3">
-                    <input type="text" class="form-control" value="https://pdfonelink.com/doc/abc123" readonly>
+                    <input type="text" class="form-control" value="https://onelinkpdf.com/doc/abc123" readonly>
                     <button class="btn btn-outline-secondary" type="button"><i class="bi bi-clipboard"></i></button>
                   </div>
                   <div class="form-check form-switch mb-2">
@@ -276,7 +276,7 @@
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Perfect For Every Use Case</h2>
-        <p class="section-subtitle">PDFOneLink helps professionals across industries share documents securely</p>
+        <p class="section-subtitle">OneLinkPDF helps professionals across industries share documents securely</p>
       </div>
 
       <div class="row g-4">
@@ -320,7 +320,7 @@
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Works With Your Tools</h2>
-        <p class="section-subtitle">PDFOneLink integrates seamlessly with the platforms you already use</p>
+        <p class="section-subtitle">OneLinkPDF integrates seamlessly with the platforms you already use</p>
       </div>
 
       <div class="d-flex flex-wrap justify-content-center align-items-center">
@@ -343,7 +343,7 @@
     <div class="container">
       <div class="row justify-content-center">
         <div class="col-lg-8 text-center">
-          <h2 class="mb-4">Ready to try PDFOneLink?</h2>
+          <h2 class="mb-4">Ready to try OneLinkPDF?</h2>
           <p class="text-muted mb-4">Start sharing your PDFs securely today. No credit card required.</p>
           <div class="d-flex justify-content-center gap-3 flex-wrap">
             <a href="{{ route('register') }}" class="btn btn-brand btn-lg">Get Started for Free</a>

--- a/resources/views/how-it-works.blade.php
+++ b/resources/views/how-it-works.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'How It Works - PDFOneLink')
+@section('title', 'How It Works - OneLinkPDF')
 
 
 @section('content')
@@ -9,7 +9,7 @@
     <div class="container position-relative">
       <div class="row justify-content-center">
         <div class="col-lg-8 text-center">
-          <h1 class="display-5 fw-bold mb-3">How PDFOneLink Works</h1>
+          <h1 class="display-5 fw-bold mb-3">How OneLinkPDF Works</h1>
           <p class="lead text-muted mb-4">Set up in minutes — upload, share, and track your PDFs with ease.</p>
         </div>
       </div>
@@ -78,7 +78,7 @@
         <div class="col-lg-6">
           <div class="detail-card">
             <h3 class="mb-4">Step 1: Account Creation &amp; Setup</h3>
-            <p>Getting started with PDFOneLink is designed to be quick and straightforward:</p>
+            <p>Getting started with OneLinkPDF is designed to be quick and straightforward:</p>
             <ul class="list-unstyled">
               <li class="mb-3"><i class="bi bi-check-circle-fill text-success me-2"></i> <strong>Sign up</strong> with your email address or social account</li>
               <li class="mb-3"><i class="bi bi-check-circle-fill text-success me-2"></i> <strong>Verify your email</strong> to activate your account</li>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'PDFOneLink — Secure PDF Sharing & Analytics in One Link')
+@section('title', 'OneLinkPDF — Secure PDF Sharing & Analytics in One Link')
 
 @section('content')
 
@@ -85,7 +85,7 @@
               {{-- HTML snippet --}}
               @verbatim
 <pre class="m-0" id="snippetHtml"><code>&lt;iframe
-  src="https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN"
+  src="https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN"
   width="100%" height="600"
   style="border:none;border-radius:12px;"
   allow="clipboard-write"&gt;&lt;/iframe&gt;</code></pre>
@@ -95,14 +95,14 @@
               @verbatim
 <pre class="m-0 d-none" id="snippetReact"><code>import React from 'react';
 
-export default function PdfOneLinkEmbed() {
+export default function OneLinkPdfEmbed() {
   return (
     &lt;iframe
-      src="https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN"
+      src="https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN"
       width="100%" height="600"
       style={{ border: 'none', borderRadius: 12 }}
       allow="clipboard-write"
-      title="PDFOneLink Viewer"
+      title="OneLinkPDF Viewer"
     /&gt;
   );
 }</code></pre>
@@ -114,21 +114,21 @@ export default function PdfOneLinkEmbed() {
 import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
-  selector: 'app-pdfonelink-embed',
+  selector: 'app-onelinkpdf-embed',
   template: `
     &lt;iframe
       [src]="docUrl"
       width="100%" height="600"
       style="border:none;border-radius:12px;"
       allow="clipboard-write"
-      title="PDFOneLink Viewer"&gt;&lt;/iframe&gt;
+      title="OneLinkPDF Viewer"&gt;&lt;/iframe&gt;
   `
 })
-export class PdfOneLinkEmbedComponent {
+export class OneLinkPdfEmbedComponent {
   docUrl: SafeResourceUrl;
   constructor(private sanitizer: DomSanitizer) {
     this.docUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
-      'https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN'
+      'https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN'
     );
   }
 }</code></pre>
@@ -200,7 +200,7 @@ export class PdfOneLinkEmbedComponent {
     <div class="container demo-container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Live Embed Demo</h2>
-        <p class="section-subtitle">See how PDFOneLink works with this interactive demo</p>
+        <p class="section-subtitle">See how OneLinkPDF works with this interactive demo</p>
       </div>
 
       <div class="row g-5 align-items-center">
@@ -227,7 +227,7 @@ export class PdfOneLinkEmbedComponent {
             </div>
 
             <div class="demo-browser">
-              <iframe src="https://www.onelinkpdf.com/view?doc=045210e8da" title="PDFOneLink Demo Viewer" allow="clipboard-write"></iframe>
+              <iframe src="https://www.onelinkpdf.com/view?doc=045210e8da" title="OneLinkPDF Demo Viewer" allow="clipboard-write"></iframe>
             </div>
 
             <div class="demo-controls">
@@ -347,7 +347,7 @@ export class PdfOneLinkEmbedComponent {
     <div class="container">
       <div class="text-center mb-5">
         <h2 class="section-title centered">Frequently asked questions</h2>
-        <p class="section-subtitle">Everything you need to know about PDFOneLink.</p>
+        <p class="section-subtitle">Everything you need to know about OneLinkPDF.</p>
       </div>
 
       <div class="row g-4">

--- a/resources/views/integrations.blade.php
+++ b/resources/views/integrations.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Integrations - PDFOneLink')
+@section('title', 'Integrations - OneLinkPDF')
 
 @section('content')
 <section class="section">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>@yield('title', 'PDFOneLink — Secure PDF Sharing & Analytics in One Link')</title>
+  <title>@yield('title', 'OneLinkPDF — Secure PDF Sharing & Analytics in One Link')</title>
 
   {{-- Vendor CSS --}}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/resources/views/layouts/partials/footer.blade.php
+++ b/resources/views/layouts/partials/footer.blade.php
@@ -3,7 +3,7 @@
     <div class="row g-5">
       <div class="col-md-6 col-lg-3">
         <h5 class="mb-4 d-flex align-items-center">
-          <img src="{{ asset('assets/logo/onelinkpdf-logo.png') }}" alt="PDFOneLink Logo" class="me-2" style="height:28px;">
+          <img src="{{ asset('assets/logo/onelinkpdf-logo.png') }}" alt="OneLinkPDF Logo" class="me-2" style="height:28px;">
         </h5>
         <p class="mb-3">Secure PDF upload, sharing, permissions, and analytics — all in one link.</p>
         <p class="small text-secondary mb-4">Token-based access, view-only controls, watermarking, and detailed analytics help you share confidently.</p>
@@ -42,7 +42,7 @@
           <li><a href="{{ url('/contact') }}">General Inquiry</a></li>
         </ul>
         <address class="small text-secondary mt-3 mb-0">
-          <div>support@pdfonelink.com</div>
+          <div>support@onelinkpdf.com</div>
           <div>+1 (555) 123-4567</div>
         </address>
       </div>
@@ -61,7 +61,7 @@
     </div>
 
     <div class="footer-bottom">
-      <p class="copyright mb-0">© {{ now()->year }} PDFOneLink. All rights reserved.</p>
+      <p class="copyright mb-0">© {{ now()->year }} OneLinkPDF. All rights reserved.</p>
       <div class="legal-links">
         <a href="{{ url('/privacy') }}">Privacy Policy</a>
         <span class="divider">•</span>

--- a/resources/views/partnerships.blade.php
+++ b/resources/views/partnerships.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Partner With Us - PDFOneLink')
+@section('title', 'Partner With Us - OneLinkPDF')
 
 
 @section('content')

--- a/resources/views/pricing.blade.php
+++ b/resources/views/pricing.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Pricing - PDFOneLink')
+@section('title', 'Pricing - OneLinkPDF')
 
 @section('content')
   {{-- HERO --}}
@@ -236,7 +236,7 @@
       <div class="row justify-content-center">
         <div class="col-lg-8 text-center">
           <h2 class="mb-4">Ready to get started?</h2>
-          <p class="text-muted mb-4">Join thousands of professionals who trust PDFOneLink with their document sharing needs.</p>
+          <p class="text-muted mb-4">Join thousands of professionals who trust OneLinkPDF with their document sharing needs.</p>
           <div class="d-flex justify-content-center gap-3 flex-wrap">
             <a href="{{ url('/register') }}" class="btn btn-brand btn-lg">Start free trial</a>
             <a href="{{ url('/contact') }}" class="btn btn-ghost btn-lg">Contact sales</a>

--- a/resources/views/privacy.blade.php
+++ b/resources/views/privacy.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Privacy Policy - PDFOneLink')
+@section('title', 'Privacy Policy - OneLinkPDF')
 
 @section('content')
 <section class="section">
@@ -8,8 +8,8 @@
     <h1 class="section-title centered">Privacy Policy</h1>
     <p class="section-subtitle">Your privacy is important to us.</p>
 
-    <p>This Privacy Policy explains how PDFOneLink collects, uses, and protects your information when you use our services.</p>
-    <p>By using PDFOneLink, you agree to the practices described here. We only collect information necessary to deliver and improve our services, and we never sell your data.</p>
+    <p>This Privacy Policy explains how OneLinkPDF collects, uses, and protects your information when you use our services.</p>
+    <p>By using OneLinkPDF, you agree to the practices described here. We only collect information necessary to deliver and improve our services, and we never sell your data.</p>
     <p>If you have any questions about this policy, please <a href="{{ url('contact') }}">contact us</a>.</p>
   </div>
 </section>

--- a/resources/views/terms.blade.php
+++ b/resources/views/terms.blade.php
@@ -1,6 +1,6 @@
 @extends('layouts.app')
 
-@section('title', 'Terms of Service - PDFOneLink')
+@section('title', 'Terms of Service - OneLinkPDF')
 
 @section('content')
 <section class="section">
@@ -8,9 +8,9 @@
     <h1 class="section-title centered">Terms of Service</h1>
     <p class="section-subtitle">Please read these terms carefully.</p>
 
-    <p>By accessing or using PDFOneLink, you agree to the following terms and conditions governing your use of our website and services.</p>
+    <p>By accessing or using OneLinkPDF, you agree to the following terms and conditions governing your use of our website and services.</p>
     <p>We may update these terms from time to time. Continued use of the service constitutes acceptance of the revised terms.</p>
-    <p>If you do not agree with these terms, please discontinue using PDFOneLink.</p>
+    <p>If you do not agree with these terms, please discontinue using OneLinkPDF.</p>
   </div>
 </section>
 @endsection

--- a/resources/views/vendor/files/embed.blade.php
+++ b/resources/views/vendor/files/embed.blade.php
@@ -3,7 +3,7 @@
 @php
   $titleText = $isImage ? 'Embed Image' : 'Embed PDF Viewer';
   $iconClass = $isImage ? 'bi-card-image text-info' : 'bi-file-earmark-pdf text-danger';
-  $embedSrc  = $url ?: 'https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN';
+  $embedSrc  = $url ?: 'https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN';
 @endphp
 
 @section('title', $titleText)
@@ -167,7 +167,7 @@
 @verbatim
 <script>
 (function(){
-  const EMBED_SRC = window.EMBED_SRC || 'https://pdfonelink.com/view?doc=YOUR_DOC_TOKEN';
+  const EMBED_SRC = window.EMBED_SRC || 'https://onelinkpdf.com/view?doc=YOUR_DOC_TOKEN';
 
   const SNIPPETS = {
     html:


### PR DESCRIPTION
## Summary
- Replace legacy PDFOneLink branding with OneLinkPDF across Blade templates, PHP pages and static assets.
- Update URLs and contact emails to use onelinkpdf.com for consistent SEO metadata.

## Testing
- `composer test` *(fails: file_get_contents(/workspace/onepdf-app-laravel/.env): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1c6147588327aa1e642231cea538