### PR TITLE
Display plan usage and enforce upload limits

### DIFF
--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -7,13 +7,46 @@ use Illuminate\Database\Eloquent\Model;
 class Plan extends Model
 {
     protected $fillable = [
-        'name', 'inr_price', 'usd_price', 'billing_cycle'
+        'name', 'inr_price', 'usd_price', 'billing_cycle', 'storage', 'monthly_file'
     ];
 
     protected $casts = [
         'inr_price' => 'decimal:2',
         'usd_price' => 'decimal:2',
     ];
+
+    /**
+     * Convert the storage string (e.g. "20 MB") to bytes.
+     */
+    public function storageBytes(): ?int
+    {
+        if (!$this->storage) {
+            return null;
+        }
+
+        if (preg_match('/^(\d+)\s*(KB|MB|GB|TB)$/i', trim($this->storage), $m)) {
+            $num  = (int) $m[1];
+            $unit = strtoupper($m[2]);
+
+            return $num * match($unit) {
+                'TB' => 1024 ** 4,
+                'GB' => 1024 ** 3,
+                'MB' => 1024 ** 2,
+                'KB' => 1024,
+                default => 1,
+            };
+        }
+
+        return (int) $this->storage;
+    }
+
+    /**
+     * Monthly file upload limit as integer.
+     */
+    public function monthlyFileLimit(): ?int
+    {
+        return $this->monthly_file !== null ? (int) $this->monthly_file : null;
+    }
 }
 
 

--- a/database/seeders/PlanSeeder.php
+++ b/database/seeders/PlanSeeder.php
@@ -10,11 +10,11 @@ class PlanSeeder extends Seeder
     public function run(): void
     {
         $rows = [
-            ['id'=>1,'name'=>'Free',     'inr_price'=>'0.00',   'usd_price'=>'0.00',  'billing_cycle'=>'free'],
-            ['id'=>2,'name'=>'Pro',      'inr_price'=>'12.00',  'usd_price'=>'12.00', 'billing_cycle'=>'month'],
-            ['id'=>3,'name'=>'Pro',      'inr_price'=>'499.00', 'usd_price'=>'499.00','billing_cycle'=>'year'],
-            ['id'=>4,'name'=>'Business', 'inr_price'=>'25.00',  'usd_price'=>'25.00', 'billing_cycle'=>'month'],
-            ['id'=>5,'name'=>'Business', 'inr_price'=>'1999.00','usd_price'=>'1999.00','billing_cycle'=>'year'],
+            ['id'=>1,'name'=>'Free',     'inr_price'=>'0.00',   'usd_price'=>'0.00',  'billing_cycle'=>'free',  'storage'=>'20 MB', 'monthly_file'=>'2'],
+            ['id'=>2,'name'=>'Pro',      'inr_price'=>'12.00',  'usd_price'=>'12.00', 'billing_cycle'=>'month', 'storage'=>'1 GB',  'monthly_file'=>'100'],
+            ['id'=>3,'name'=>'Pro',      'inr_price'=>'499.00', 'usd_price'=>'499.00','billing_cycle'=>'year',  'storage'=>'1 GB',  'monthly_file'=>'100'],
+            ['id'=>4,'name'=>'Business', 'inr_price'=>'25.00',  'usd_price'=>'25.00', 'billing_cycle'=>'month', 'storage'=>'5 GB',  'monthly_file'=>'500'],
+            ['id'=>5,'name'=>'Business', 'inr_price'=>'1999.00','usd_price'=>'1999.00','billing_cycle'=>'year', 'storage'=>'5 GB',  'monthly_file'=>'500'],
         ];
 
         foreach ($rows as $data) {

--- a/resources/views/vendor/plan/index.blade.php
+++ b/resources/views/vendor/plan/index.blade.php
@@ -88,6 +88,8 @@
         @else
           <p>You are currently on the <strong>Free</strong> plan.</p>
         @endif
+        <p>Storage used: {{ $usedReadable }}@if($limitReadable) / {{ $limitReadable }} @endif</p>
+        <p>Files this month: {{ $monthlyCount }}@if($monthlyLimit) / {{ $monthlyLimit }} @endif</p>
         <button class="btn btn-outline-dark mt-3" data-bs-toggle="modal" data-bs-target="#upgradeModal">
           <i class="bi bi-arrow-up-circle me-1"></i> Upgrade Plan
         </button>


### PR DESCRIPTION
## Summary
- show storage and monthly file usage on vendor plan page
- enforce plan storage and monthly file limits during uploads
- add plan attributes for storage and monthly file limits

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c67133772883278573a6a424e008ad