### PR TITLE
Fix vendor dashboard route naming and login redirect

### DIFF
--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -33,7 +33,7 @@ class LoginController extends Controller
             Session::put('user_name', $user->first_name ?? $user->name ?? '');
             Session::put('use_id', $user->use_id ?? null);
 
-            $redirect = $user->is_admin ? route('admin.dashboard') : route('dashboard');
+            $redirect = $user->is_admin ? route('admin.dashboard') : route('vendor.dashboard');
 
             return response()->json([
                 'success' => true,

--- a/routes/web.php
+++ b/routes/web.php
@@ -63,7 +63,7 @@ Route::post('/partnerships', [PartnershipsController::class, 'store'])->name('pa
 
 /* ------------------------- Vendor dashboard ------------------------- */
 Route::prefix('vendor')->middleware('auth')->group(function () {
-    Route::get('dashboard', [DashboardController::class, 'index'])->name('dashboard');
+    Route::get('dashboard', [DashboardController::class, 'index'])->name('vendor.dashboard');
 
     Route::get('profile', [ProfileController::class, 'edit'])->name('profile');
     Route::put('profile', [ProfileController::class, 'update'])->name('profile.update');


### PR DESCRIPTION
## Summary
- Ensure vendor dashboard route uses vendor.dashboard name
- Update login redirect to use vendor dashboard route

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c6777272c083278b58a7b444688cba