### PR TITLE
Fix vendor dashboard route references

### DIFF
--- a/resources/views/vendor/analytics/document.blade.php
+++ b/resources/views/vendor/analytics/document.blade.php
@@ -18,7 +18,7 @@
 @section('content')
 <div class="container py-3">
   <nav class="crumb mb-2">
-    <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+    <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
     <i class="bi bi-chevron-right"></i>
     <a href="{{ route('vendor.analytics.document', $doc->id) }}">Analytics</a>
     <i class="bi bi-chevron-right"></i>

--- a/resources/views/vendor/analytics/documents.blade.php
+++ b/resources/views/vendor/analytics/documents.blade.php
@@ -90,7 +90,7 @@
     <div class="container py-3">
       <div class="d-flex align-items-center justify-content-between">
         <nav class="crumb">
-          <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+          <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
           <i class="bi bi-chevron-right"></i>
           <a href="{{ route('vendor.analytics.index') }}">Analytics</a>
           <i class="bi bi-chevron-right"></i>

--- a/resources/views/vendor/analytics/index.blade.php
+++ b/resources/views/vendor/analytics/index.blade.php
@@ -104,7 +104,7 @@
     <div class="container py-3">
       <div class="d-flex align-items-center justify-content-between">
         <nav class="crumb">
-          <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+          <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
           <i class="bi bi-chevron-right"></i>
           <span>Analytics</span>
         </nav>

--- a/resources/views/vendor/dashboard/index.blade.php
+++ b/resources/views/vendor/dashboard/index.blade.php
@@ -39,9 +39,9 @@
           @endphp
           <button class="btn btn-outline-dark dropdown-toggle" data-bs-toggle="dropdown"><i class="bi bi-clock-history me-1"></i> {{ $label }}</button>
           <ul class="dropdown-menu">
-            <li><a class="dropdown-item" href="{{ route('dashboard', ['days' => 7]) }}">Last 7 days</a></li>
-            <li><a class="dropdown-item" href="{{ route('dashboard', ['days' => 15]) }}">Last 15 days</a></li>
-            <li><a class="dropdown-item" href="{{ route('dashboard', ['days' => 30]) }}">Last 30 days</a></li>
+            <li><a class="dropdown-item" href="{{ route('vendor.dashboard', ['days' => 7]) }}">Last 7 days</a></li>
+            <li><a class="dropdown-item" href="{{ route('vendor.dashboard', ['days' => 15]) }}">Last 15 days</a></li>
+            <li><a class="dropdown-item" href="{{ route('vendor.dashboard', ['days' => 30]) }}">Last 30 days</a></li>
           </ul>
         </div>
         <a href="{{ route('vendor.files.index') }}" class="btn btn-dark"><i class="bi bi-card-list me-1"></i> View All Time</a>

--- a/resources/views/vendor/files/embed.blade.php
+++ b/resources/views/vendor/files/embed.blade.php
@@ -72,7 +72,7 @@
   <div class="container py-3">
     <div class="d-flex align-items-center justify-content-between">
       <nav class="crumb">
-        <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
         <i class="bi bi-chevron-right"></i>
         <a href="{{ route('vendor.files.manage') }}">Manage Files</a>
         <i class="bi bi-chevron-right"></i>

--- a/resources/views/vendor/files/index.blade.php
+++ b/resources/views/vendor/files/index.blade.php
@@ -94,7 +94,7 @@
     <div class="container py-3">
       <div class="d-flex align-items-center justify-content-between">
         <nav class="crumb">
-          <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+          <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
           <i class="bi bi-chevron-right"></i>
           <span>Upload Files</span>
         </nav>

--- a/resources/views/vendor/files/manage.blade.php
+++ b/resources/views/vendor/files/manage.blade.php
@@ -84,7 +84,7 @@
   <div class="container py-3">
     <div class="d-flex align-items-center justify-content-between">
       <nav class="crumb">
-        <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
         <i class="bi bi-chevron-right"></i>
         <span>Manage Files</span>
       </nav>

--- a/resources/views/vendor/help/manage.blade.php
+++ b/resources/views/vendor/help/manage.blade.php
@@ -89,7 +89,7 @@
 <div class="top-band">
   <div class="container py-3">
     <nav class="crumb">
-      <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+      <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
       <i class="bi bi-chevron-right"></i>
       <span>Help</span>
     </nav>

--- a/resources/views/vendor/layouts/partials/sidebar.blade.php
+++ b/resources/views/vendor/layouts/partials/sidebar.blade.php
@@ -15,7 +15,7 @@
   <!-- NEW MENU -->
   <nav class="nav flex-column gap-1" id="mainNav">
     <div class="side-title">GENERAL</div>
-    <a class="nav-link {{ request()->routeIs('dashboard') ? 'active' : '' }}" href="{{ route('dashboard') }}">
+    <a class="nav-link {{ request()->routeIs('vendor.dashboard') ? 'active' : '' }}" href="{{ route('vendor.dashboard') }}">
       <i class="bi bi-speedometer2"></i> <span>Dashboard</span>
     </a>
     <a class="nav-link {{ request()->routeIs('vendor.files.index') ? 'active' : '' }}" href="{{ route('vendor.files.index') }}">

--- a/resources/views/vendor/lead_forms/edit.blade.php
+++ b/resources/views/vendor/lead_forms/edit.blade.php
@@ -101,7 +101,7 @@
     <div class="container py-3">
       <div class="d-flex align-items-center justify-content-between">
         <nav class="crumb">
-          <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+          <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
           <i class="bi bi-chevron-right"></i>
           <a href="{{ route('vendor.lead_forms.index') }}">Lead Forms</a>
           <i class="bi bi-chevron-right"></i>

--- a/resources/views/vendor/lead_forms/index.blade.php
+++ b/resources/views/vendor/lead_forms/index.blade.php
@@ -95,7 +95,7 @@
   <div class="container py-3">
     <div class="d-flex align-items-center justify-content-between">
       <nav class="crumb">
-        <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
         <i class="bi bi-chevron-right"></i>
         <span>Lead Forms</span>
       </nav>

--- a/resources/views/vendor/leads/index.blade.php
+++ b/resources/views/vendor/leads/index.blade.php
@@ -85,7 +85,7 @@
   <div class="container py-3">
     <div class="d-flex align-items-center justify-content-between">
       <nav class="crumb">
-        <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
         <i class="bi bi-chevron-right"></i>
         <span>Leads</span>
       </nav>

--- a/resources/views/vendor/notifications/index.blade.php
+++ b/resources/views/vendor/notifications/index.blade.php
@@ -5,7 +5,7 @@
 @section('content')
   <div class="bw-band">
     <ol class="bw-crumb">
-      <li><a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i>Home</a></li>
+      <li><a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i>Home</a></li>
       <li>Notifications</li>
     </ol>
   </div>

--- a/resources/views/vendor/password/edit.blade.php
+++ b/resources/views/vendor/password/edit.blade.php
@@ -71,7 +71,7 @@
     <div class="container py-3">
       <div class="d-flex align-items-center justify-content-between">
         <nav class="crumb">
-          <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+          <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
           <i class="bi bi-chevron-right"></i>
           <span>Change Password</span>
         </nav>

--- a/resources/views/vendor/plan/index.blade.php
+++ b/resources/views/vendor/plan/index.blade.php
@@ -69,7 +69,7 @@
   <div class="top-band">
     <div class="container py-3">
       <nav class="crumb">
-        <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
         <i class="bi bi-chevron-right"></i>
         <span>Plan</span>
       </nav>

--- a/resources/views/vendor/profile/edit.blade.php
+++ b/resources/views/vendor/profile/edit.blade.php
@@ -94,7 +94,7 @@
     <div class="container py-3">
       <div class="d-flex align-items-center justify-content-between">
         <nav class="crumb">
-          <a href="{{ route('dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+          <a href="{{ route('vendor.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
           <i class="bi bi-chevron-right"></i>
           <span>Profile</span>
         </nav>


### PR DESCRIPTION
## Summary
- update vendor views to use `vendor.dashboard` route name

## Testing
- `composer test` *(fails: require vendor/autoload.php: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c6b240203083279bc194304174e924