### PR TITLE
Add dynamic sitemap and refund policy page

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -99,6 +99,14 @@ class HomeController extends Controller
     }
 
     /**
+     * Display the refund policy page.
+     */
+    public function refundPolicy()
+    {
+        return view('refund-policy');
+    }
+
+    /**
      * Display the documentation page.
      */
     public function docs()

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Route;
+
+class SitemapController extends Controller
+{
+    /**
+     * Display the XML sitemap for public pages.
+     */
+    public function index(): Response
+    {
+        $routeNames = [
+            'home',
+            'features',
+            'pricing',
+            'how-it-works',
+            'contact',
+            'partnerships',
+            'docs',
+            'integrations',
+            'terms',
+            'privacy',
+            'refund-policy',
+        ];
+
+        $urls = collect($routeNames)
+            ->filter(fn ($name) => Route::has($name))
+            ->map(function ($name) {
+                try {
+                    $loc = route($name);
+                } catch (\InvalidArgumentException $e) {
+                    return null;
+                }
+
+                return [
+                    'loc' => $loc,
+                    'lastmod' => now()->toAtomString(),
+                    'changefreq' => $name === 'home' ? 'daily' : 'weekly',
+                    'priority' => $name === 'home' ? '1.0' : '0.8',
+                ];
+            })
+            ->filter()
+            ->values();
+
+        return response()
+            ->view('sitemap', ['urls' => $urls])
+            ->header('Content-Type', 'application/xml');
+    }
+}

--- a/resources/views/layouts/partials/footer.blade.php
+++ b/resources/views/layouts/partials/footer.blade.php
@@ -68,6 +68,8 @@
         <span class="divider">•</span>
         <a href="{{ url('/terms') }}">Terms of Service</a>
         <span class="divider">•</span>
+        <a href="{{ url('/refund-policy') }}">Refund Policy</a>
+        <span class="divider">•</span>
         <a href="{{ url('/sitemap.xml') }}">Sitemap</a>
       </div>
     </div>

--- a/resources/views/refund-policy.blade.php
+++ b/resources/views/refund-policy.blade.php
@@ -1,0 +1,16 @@
+@extends('layouts.app')
+
+@section('title', 'Refund Policy - OneLinkPDF')
+
+@section('content')
+<section class="section">
+  <div class="container">
+    <h1 class="section-title centered">Refund Policy</h1>
+    <p class="section-subtitle">Transparency on refunds and cancellations.</p>
+
+    <p>We want you to love using OneLinkPDF. If the service isn&apos;t the right fit, you can request a refund within 14 days of your initial purchase on paid plans.</p>
+    <p>Refunds are evaluated on a case-by-case basis and are issued back to the original payment method once approved. To begin the process, please <a href="{{ url('contact') }}">contact our support team</a> with your account details and purchase receipt.</p>
+    <p>After 14 days, refunds are not guaranteed, but we&apos;re always available to help you resolve any issues or adjust your plan so it better matches your needs.</p>
+  </div>
+</section>
+@endsection

--- a/resources/views/sitemap.blade.php
+++ b/resources/views/sitemap.blade.php
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+@foreach ($urls as $url)
+  <url>
+    <loc>{{ $url['loc'] }}</loc>
+    <lastmod>{{ $url['lastmod'] }}</lastmod>
+    <changefreq>{{ $url['changefreq'] }}</changefreq>
+    <priority>{{ $url['priority'] }}</priority>
+  </url>
+@endforeach
+</urlset>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\LeadCaptureController;
+use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\NewsletterSubscriptionController;
 use App\Http\Controllers\PartnershipsController;
 use App\Http\Controllers\Vendor\AnalyticsController;
@@ -51,9 +52,11 @@ Route::get('/contact', [HomeController::class, 'contact'])->name('contact');
 Route::get('/partnerships', [HomeController::class, 'partnerships'])->name('partnerships');
 Route::get('/terms', [HomeController::class, 'terms'])->name('terms');
 Route::get('/privacy', [HomeController::class, 'privacy'])->name('privacy');
+Route::get('/refund-policy', [HomeController::class, 'refundPolicy'])->name('refund-policy');
 Route::get('/docs', [HomeController::class, 'docs'])->name('docs');
 Route::get('/integrations', [HomeController::class, 'integrations'])->name('integrations');
 Route::post('/subscribe', [NewsletterSubscriptionController::class, 'store'])->name('subscribe');
+Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap');
 
 /* Contact + Partnerships (AJAX) */
 Route::post('/contact', [ContactController::class, 'store'])->name('contact.store');


### PR DESCRIPTION
## Summary
- add a refund policy view and route so marketing pages cover the new policy
- implement a sitemap controller and blade template to generate a dynamic sitemap.xml
- update footer legal links to include the refund policy and dynamic sitemap entry

## Testing
- php artisan test *(warnings: missing `.env` file in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c849ebde848327b4097785bbad59bf