### PR TITLE
Add blog system with admin management and public pages

### DIFF
--- a/app/Http/Controllers/Admin/BlogController.php
+++ b/app/Http/Controllers/Admin/BlogController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\BlogPost;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class BlogController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): View
+    {
+        $posts = BlogPost::orderByDesc('created_at')->paginate(10);
+
+        return view('admin.blogs.index', compact('posts'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(): View
+    {
+        $post = new BlogPost([
+            'is_published' => true,
+        ]);
+
+        return view('admin.blogs.create', compact('post'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $this->validatedData($request);
+
+        $post = BlogPost::create($data);
+
+        return redirect()
+            ->route('admin.blogs.edit', $post)
+            ->with('status', 'Blog post created successfully.');
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(BlogPost $blog): View
+    {
+        return view('admin.blogs.edit', ['post' => $blog]);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, BlogPost $blog): RedirectResponse
+    {
+        $data = $this->validatedData($request, $blog);
+
+        $blog->update($data);
+
+        return redirect()
+            ->route('admin.blogs.edit', $blog)
+            ->with('status', 'Blog post updated successfully.');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(BlogPost $blog): RedirectResponse
+    {
+        $blog->delete();
+
+        return redirect()
+            ->route('admin.blogs.index')
+            ->with('status', 'Blog post deleted successfully.');
+    }
+
+    /**
+     * Validate the request data and prepare it for persistence.
+     */
+    protected function validatedData(Request $request, ?BlogPost $blog = null): array
+    {
+        $validated = $request->validate([
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'excerpt' => ['nullable', 'string'],
+            'content' => ['required', 'string'],
+            'is_published' => ['nullable', 'boolean'],
+        ]);
+
+        $validated['is_published'] = $request->boolean('is_published');
+
+        $slugSource = $validated['slug'] ?? $validated['title'];
+        $slug = Str::slug($slugSource);
+        if ($slug === '') {
+            $slug = Str::slug(Str::random(8));
+        }
+        $validated['slug'] = $this->ensureUniqueSlug($slug, $blog?->id);
+
+        if ($validated['is_published']) {
+            $validated['published_at'] = $blog && $blog->published_at
+                ? $blog->published_at
+                : now();
+        } else {
+            $validated['published_at'] = null;
+        }
+
+        return $validated;
+    }
+
+    /**
+     * Ensure the slug is unique in the database.
+     */
+    protected function ensureUniqueSlug(string $slug, ?int $ignoreId = null): string
+    {
+        $original = $slug;
+        $counter = 2;
+
+        while ($this->slugExists($slug, $ignoreId)) {
+            $slug = $original . '-' . $counter;
+            $counter++;
+        }
+
+        return $slug;
+    }
+
+    /**
+     * Determine if a slug already exists.
+     */
+    protected function slugExists(string $slug, ?int $ignoreId = null): bool
+    {
+        return BlogPost::where('slug', $slug)
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->exists();
+    }
+}

--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\BlogPost;
+use Illuminate\Contracts\View\View;
+
+class BlogController extends Controller
+{
+    /**
+     * Display a listing of published blog posts.
+     */
+    public function index(): View
+    {
+        $posts = BlogPost::published()
+            ->orderByDesc('published_at')
+            ->orderByDesc('created_at')
+            ->paginate(9);
+
+        return view('blog.index', compact('posts'));
+    }
+
+    /**
+     * Display a single blog post.
+     */
+    public function show(string $slug): View
+    {
+        $post = BlogPost::published()
+            ->where('slug', $slug)
+            ->firstOrFail();
+
+        $relatedPosts = BlogPost::published()
+            ->where('id', '!=', $post->id)
+            ->orderByDesc('published_at')
+            ->orderByDesc('created_at')
+            ->limit(3)
+            ->get();
+
+        return view('blog.show', compact('post', 'relatedPosts'));
+    }
+}

--- a/app/Http/Controllers/SitemapController.php
+++ b/app/Http/Controllers/SitemapController.php
@@ -21,6 +21,7 @@ class SitemapController extends Controller
             'partnerships',
             'docs',
             'integrations',
+            'blog.index',
             'terms',
             'privacy',
             'refund-policy',

--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Builder;
+
+class BlogPost extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'title',
+        'slug',
+        'excerpt',
+        'content',
+        'is_published',
+        'published_at',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'is_published' => 'boolean',
+        'published_at' => 'datetime',
+    ];
+
+    /**
+     * Scope the query to only include published posts.
+     */
+    public function scopePublished(Builder $query): Builder
+    {
+        return $query->where('is_published', true)
+            ->where(function (Builder $inner) {
+                $inner->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            });
+    }
+
+    /**
+     * Use the slug for route model binding.
+     */
+    public function getRouteKeyName(): string
+    {
+        return 'slug';
+    }
+}

--- a/database/migrations/2025_09_15_180511_create_blog_posts_table.php
+++ b/database/migrations/2025_09_15_180511_create_blog_posts_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('blog_posts', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('slug')->unique();
+            $table->text('excerpt')->nullable();
+            $table->longText('content');
+            $table->boolean('is_published')->default(false);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('blog_posts');
+    }
+};

--- a/resources/views/admin/blogs/create.blade.php
+++ b/resources/views/admin/blogs/create.blade.php
@@ -1,0 +1,48 @@
+@extends('admin.layouts.app')
+
+@section('title', 'Create Blog Post')
+
+@include('admin.blogs.partials.styles')
+
+@section('content')
+<div class="top-band">
+  <div class="container py-3">
+    <div class="d-flex align-items-center justify-content-between flex-wrap gap-3">
+      <nav class="crumb">
+        <a href="{{ route('admin.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <i class="bi bi-chevron-right"></i>
+        <a href="{{ route('admin.blogs.index') }}" class="text-decoration-none">Blog</a>
+        <i class="bi bi-chevron-right"></i>
+        <span>New post</span>
+      </nav>
+    </div>
+  </div>
+</div>
+
+<div class="container py-3">
+  @if ($errors->any())
+    <div class="alert-error mb-3">
+      <div class="fw-semibold mb-1">Please fix the following:</div>
+      <ul class="mb-0 ps-3">
+        @foreach ($errors->all() as $error)
+          <li>{{ $error }}</li>
+        @endforeach
+      </ul>
+    </div>
+  @endif
+
+  <div class="card">
+    <div class="card-header">
+      <h5 class="mb-0">Create blog post</h5>
+    </div>
+    <div class="card-body">
+      @include('admin.blogs.partials.form', [
+        'action' => route('admin.blogs.store'),
+        'method' => 'POST',
+        'post' => $post,
+        'submitLabel' => 'Create post',
+      ])
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/blogs/edit.blade.php
+++ b/resources/views/admin/blogs/edit.blade.php
@@ -1,0 +1,57 @@
+@extends('admin.layouts.app')
+
+@section('title', 'Edit Blog Post')
+
+@include('admin.blogs.partials.styles')
+
+@section('content')
+<div class="top-band">
+  <div class="container py-3">
+    <div class="d-flex align-items-center justify-content-between flex-wrap gap-3">
+      <nav class="crumb">
+        <a href="{{ route('admin.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <i class="bi bi-chevron-right"></i>
+        <a href="{{ route('admin.blogs.index') }}" class="text-decoration-none">Blog</a>
+        <i class="bi bi-chevron-right"></i>
+        <span>Edit post</span>
+      </nav>
+      @if ($post->is_published)
+        <a href="{{ route('blog.show', $post->slug) }}" target="_blank" class="btn btn-outline-dark">
+          <i class="bi bi-box-arrow-up-right me-1"></i> View live
+        </a>
+      @endif
+    </div>
+  </div>
+</div>
+
+<div class="container py-3">
+  @if (session('status'))
+    <div class="alert-status mb-3">{{ session('status') }}</div>
+  @endif
+
+  @if ($errors->any())
+    <div class="alert-error mb-3">
+      <div class="fw-semibold mb-1">Please fix the following:</div>
+      <ul class="mb-0 ps-3">
+        @foreach ($errors->all() as $error)
+          <li>{{ $error }}</li>
+        @endforeach
+      </ul>
+    </div>
+  @endif
+
+  <div class="card">
+    <div class="card-header">
+      <h5 class="mb-0">Edit blog post</h5>
+    </div>
+    <div class="card-body">
+      @include('admin.blogs.partials.form', [
+        'action' => route('admin.blogs.update', $post),
+        'method' => 'PUT',
+        'post' => $post,
+        'submitLabel' => 'Save changes',
+      ])
+    </div>
+  </div>
+</div>
+@endsection

--- a/resources/views/admin/blogs/index.blade.php
+++ b/resources/views/admin/blogs/index.blade.php
@@ -1,0 +1,92 @@
+@extends('admin.layouts.app')
+
+@section('title', 'Blog Posts')
+
+@include('admin.blogs.partials.styles')
+
+@section('content')
+<div class="top-band">
+  <div class="container py-3">
+    <div class="d-flex align-items-center justify-content-between flex-wrap gap-3">
+      <nav class="crumb">
+        <a href="{{ route('admin.dashboard') }}"><i class="bi bi-house-door me-1"></i> Home</a>
+        <i class="bi bi-chevron-right"></i>
+        <span>Blog</span>
+      </nav>
+      <a href="{{ route('admin.blogs.create') }}" class="btn btn-dark"><i class="bi bi-plus-lg me-1"></i> New post</a>
+    </div>
+  </div>
+</div>
+
+<div class="container py-3">
+  @if (session('status'))
+    <div class="alert-status mb-3">{{ session('status') }}</div>
+  @endif
+
+  <div class="card">
+    <div class="card-header">
+      <div class="files-toolbar">
+        <div class="folder"><i class="bi bi-journal-text"></i> Blog posts <span class="count">{{ $posts->total() }}</span></div>
+      </div>
+    </div>
+
+    <div class="table-responsive">
+      <table class="table align-middle mb-0">
+        <thead>
+          <tr>
+            <th>Title</th>
+            <th>Slug</th>
+            <th>Status</th>
+            <th>Published</th>
+            <th>Updated</th>
+            <th class="text-end">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          @forelse ($posts as $post)
+            <tr>
+              <td>
+                <div class="fw-semibold">{{ $post->title }}</div>
+                <div class="text-muted small">Created {{ $post->created_at?->format('M j, Y') }}</div>
+              </td>
+              <td class="text-muted">{{ $post->slug }}</td>
+              <td>
+                @if ($post->is_published)
+                  <span class="status-badge status-live"><i class="bi bi-broadcast"></i> Published</span>
+                @else
+                  <span class="status-badge status-draft"><i class="bi bi-eye-slash"></i> Draft</span>
+                @endif
+              </td>
+              <td>{{ $post->published_at?->format('M j, Y') ?? '—' }}</td>
+              <td>{{ $post->updated_at?->diffForHumans() }}</td>
+              <td class="text-end">
+                <div class="actions">
+                  <a href="{{ route('admin.blogs.edit', $post) }}" class="btn btn-sm btn-outline-dark">Edit</a>
+                  <form action="{{ route('admin.blogs.destroy', $post) }}" method="POST" onsubmit="return confirm('Delete this post?');">
+                    @csrf
+                    @method('DELETE')
+                    <button type="submit" class="btn btn-sm btn-outline-danger">Delete</button>
+                  </form>
+                </div>
+              </td>
+            </tr>
+          @empty
+            <tr>
+              <td colspan="6" class="text-center text-muted py-4">No posts yet. Create your first blog post.</td>
+            </tr>
+          @endforelse
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <nav class="mt-4 pagination-wrap" aria-label="Blog posts pagination">
+    @if ($posts->total())
+      <div class="pager-summary">Showing {{ $posts->firstItem() }}–{{ $posts->lastItem() }} of {{ $posts->total() }}</div>
+    @endif
+    <div class="pagination-modern">
+      {{ $posts->onEachSide(1)->links('pagination::bootstrap-5') }}
+    </div>
+  </nav>
+</div>
+@endsection

--- a/resources/views/admin/blogs/partials/form.blade.php
+++ b/resources/views/admin/blogs/partials/form.blade.php
@@ -1,0 +1,50 @@
+<form action="{{ $action }}" method="POST" class="needs-validation" novalidate>
+  @csrf
+  @isset($method)
+    @if (strtoupper($method) !== 'POST')
+      @method($method)
+    @endif
+  @endisset
+
+  <div class="mb-4">
+    <label for="title" class="form-label">Title</label>
+    <input type="text" class="form-control @error('title') is-invalid @enderror" id="title" name="title" value="{{ old('title', $post->title) }}" required>
+    @error('title')
+      <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+  </div>
+
+  <div class="mb-4">
+    <label for="slug" class="form-label">Slug <span class="form-text">(optional)</span></label>
+    <input type="text" class="form-control @error('slug') is-invalid @enderror" id="slug" name="slug" value="{{ old('slug', $post->slug) }}" placeholder="auto-generated from title">
+    @error('slug')
+      <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+  </div>
+
+  <div class="mb-4">
+    <label for="excerpt" class="form-label">Excerpt <span class="form-text">(short summary for listings)</span></label>
+    <textarea class="form-control @error('excerpt') is-invalid @enderror" id="excerpt" name="excerpt" rows="3">{{ old('excerpt', $post->excerpt) }}</textarea>
+    @error('excerpt')
+      <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+  </div>
+
+  <div class="mb-4">
+    <label for="content" class="form-label">Content</label>
+    <textarea class="form-control @error('content') is-invalid @enderror" id="content" name="content" rows="12" required>{{ old('content', $post->content) }}</textarea>
+    @error('content')
+      <div class="invalid-feedback">{{ $message }}</div>
+    @enderror
+  </div>
+
+  <div class="form-check form-switch mb-4">
+    <input class="form-check-input" type="checkbox" role="switch" id="is_published" name="is_published" value="1" {{ old('is_published', $post->is_published) ? 'checked' : '' }}>
+    <label class="form-check-label" for="is_published">Publish immediately</label>
+  </div>
+
+  <div class="d-flex justify-content-between align-items-center">
+    <a href="{{ route('admin.blogs.index') }}" class="btn btn-outline-secondary">Cancel</a>
+    <button type="submit" class="btn btn-dark">{{ $submitLabel }}</button>
+  </div>
+</form>

--- a/resources/views/admin/blogs/partials/styles.blade.php
+++ b/resources/views/admin/blogs/partials/styles.blade.php
@@ -1,0 +1,89 @@
+@push('styles')
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --surface:#fff; --bg:#f6f7fb; --text:#0f172a; --muted:#64748b; --line:#eaeef3;
+    --radius:14px; --shadow:0 10px 30px rgba(2,6,23,.06);
+  }
+  *{font-family:"DM Sans",system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+  body{background:var(--bg)}
+  .card{border:0;border-radius:var(--radius);box-shadow:var(--shadow)}
+  .card-header{background:#fff;border-bottom:1px solid var(--line);padding:14px 16px}
+  .card-body{padding:24px}
+
+  .top-band{
+    background: radial-gradient(1200px 220px at 50% -140px, rgba(59,130,246,.18) 0%, rgba(59,130,246,0) 60%),
+                linear-gradient(180deg,#f6f7fb 0%,#f6f7fb 60%,transparent 100%);
+    border-bottom:1px solid var(--line);
+  }
+  .crumb{ display:flex; align-items:center; gap:.5rem; font-size:.95rem; color:#64748b; }
+  .crumb a{ color:#0f172a; text-decoration:none; }
+  .crumb i{ opacity:.6; }
+
+  .files-toolbar{display:flex;align-items:center;gap:12px;flex-wrap:wrap;justify-content:space-between}
+  .folder{font-weight:600;color:var(--text);display:flex;align-items:center;gap:8px}
+  .count{display:inline-flex;min-width:26px;height:26px;padding:0 8px;border-radius:999px;background:#f0f2f7;color:#111;align-items:center;justify-content:center;font-size:.85rem;font-weight:600}
+  .table td,.table th{vertical-align:middle}
+  thead th{color:#475569;font-weight:600;border-bottom:1px solid var(--line);background:#fff}
+  tbody td{border-color:var(--line)}
+  .status-badge{display:inline-flex;align-items:center;gap:.35rem;padding:.3rem .65rem;border-radius:999px;font-weight:600;font-size:.8rem}
+  .status-live{background:rgba(34,197,94,.12);color:#15803d}
+  .status-draft{background:rgba(148,163,184,.16);color:#475569}
+  .actions{display:flex;gap:.5rem}
+
+  .alert-status{
+    border-radius:12px;
+    border:1px solid rgba(34,197,94,.2);
+    background:rgba(34,197,94,.08);
+    color:#166534;
+    padding:12px 16px;
+    font-weight:500;
+  }
+  .alert-error{
+    border-radius:12px;
+    border:1px solid rgba(220,38,38,.22);
+    background:rgba(248,113,113,.12);
+    color:#b91c1c;
+    padding:12px 16px;
+    font-weight:500;
+  }
+
+  .form-label{font-weight:600;color:#0f172a}
+  .form-text{color:var(--muted)}
+  .form-control,
+  textarea.form-control{
+    border:1px solid var(--line);
+    border-radius:12px;
+    padding:12px 14px;
+  }
+  .form-control:focus,
+  textarea.form-control:focus{
+    border-color:#cfd2d8;
+    box-shadow:0 0 0 .2rem rgba(15,23,42,.08);
+  }
+  textarea.form-control{min-height:140px}
+  .form-switch .form-check-input{width:3em;height:1.5em}
+  .form-switch .form-check-input:focus{box-shadow:0 0 0 .2rem rgba(15,23,42,.08)}
+  .form-switch .form-check-input:checked{background-color:#111;border-color:#111}
+  .invalid-feedback{display:block;font-size:.85rem;color:#dc2626}
+
+  .pagination-wrap{display:flex;flex-direction:column;align-items:center;gap:8px}
+  .pager-summary{color:#64748b;font-size:.9rem}
+  .pagination-modern{gap:8px}
+  .pagination-modern .page-link{
+    border:1px solid var(--line);
+    background:#fff;
+    color:#111;
+    border-radius:12px;
+    min-width:42px;height:42px;
+    padding:0 12px;
+    display:flex;align-items:center;justify-content:center;
+    font-weight:700;
+    box-shadow:0 2px 6px rgba(0,0,0,.04);
+  }
+  .pagination-modern .page-item.active .page-link{background:#111;border-color:#111;color:#fff}
+  .pagination-modern .page-item:not(.active):not(.disabled) .page-link:hover{background:#f2f4f7}
+  .pagination-modern .page-item.disabled .page-link{opacity:.45;cursor:not-allowed}
+</style>
+@endpush

--- a/resources/views/admin/layouts/partials/sidebar.blade.php
+++ b/resources/views/admin/layouts/partials/sidebar.blade.php
@@ -5,13 +5,13 @@
          alt="ONELINKPDF logo"
          class="brand-logo" style="height: 35px;">
   </a>
-  
+
 
   <!-- Close button for sidebar (visible on mobile) -->
   <button class="sidebar-close" id="sidebarClose">
     <i class="bi bi-x-lg"></i>
   </button>
-  
+
   <!-- NEW MENU -->
   <nav class="nav flex-column gap-1" id="mainNav">
     <div class="side-title">GENERAL</div>
@@ -23,6 +23,9 @@
     </a>
     <a class="nav-link {{ request()->routeIs('admin.user-plans.*') ? 'active' : '' }}" href="{{ route('admin.user-plans.index') }}">
       <i class="bi bi-gem"></i> <span>User Plans</span>
+    </a>
+    <a class="nav-link {{ request()->routeIs('admin.blogs.*') ? 'active' : '' }}" href="{{ route('admin.blogs.index') }}">
+      <i class="bi bi-journal-text"></i> <span>Blog</span>
     </a>
   </nav>
 

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -1,0 +1,56 @@
+@extends('layouts.app')
+
+@section('title', 'Blog - OneLinkPDF')
+
+@include('blog.partials.styles')
+
+@section('content')
+<section class="blog-hero">
+  <div class="container">
+    <div class="row align-items-center g-4">
+      <div class="col-lg-8">
+        <span class="badge mb-3">OneLinkPDF Blog</span>
+        <h1 class="display-5 fw-bold mb-3">Insights on secure document sharing & analytics</h1>
+        <p class="lead">Product updates, best practices, and stories about making documents safer to share.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="blog-section">
+  <div class="container">
+    @if ($posts->count())
+      <div class="row g-4">
+        @foreach ($posts as $post)
+          <div class="col-md-6 col-lg-4">
+            <article class="blog-card">
+              <div class="blog-card__meta">
+                <i class="bi bi-calendar3"></i>
+                <span>{{ $post->published_at?->format('M j, Y') ?? $post->created_at?->format('M j, Y') }}</span>
+              </div>
+              <h3 class="blog-card__title">
+                <a href="{{ route('blog.show', $post->slug) }}">{{ $post->title }}</a>
+              </h3>
+              <p class="blog-card__excerpt">
+                {{ $post->excerpt ?: \Illuminate\Support\Str::limit(strip_tags($post->content), 160) }}
+              </p>
+              <div class="blog-card__footer">
+                Read more <i class="bi bi-arrow-right"></i>
+              </div>
+            </article>
+          </div>
+        @endforeach
+      </div>
+
+      <div class="blog-pagination">
+        <div class="pager-summary">Showing {{ $posts->firstItem() }}–{{ $posts->lastItem() }} of {{ $posts->total() }} posts</div>
+        {{ $posts->onEachSide(1)->links('pagination::bootstrap-5') }}
+      </div>
+    @else
+      <div class="blog-empty">
+        <p>No blog posts yet. Check back soon for the latest updates.</p>
+      </div>
+    @endif
+  </div>
+</section>
+@endsection

--- a/resources/views/blog/partials/styles.blade.php
+++ b/resources/views/blog/partials/styles.blade.php
@@ -1,0 +1,72 @@
+@push('styles')
+<style>
+  .blog-hero{
+    padding:72px 0 48px;
+    background:
+      radial-gradient(900px 420px at 85% -120px, rgba(0,0,0,.05) 0%, rgba(0,0,0,0) 60%),
+      radial-gradient(700px 380px at -10% 110%, rgba(0,0,0,.05) 0%, rgba(0,0,0,0) 60%),
+      linear-gradient(180deg, #fbfbfc 0%, #f8f9fb 48%, #ffffff 100%);
+  }
+  .blog-hero .lead{color:var(--muted,#6b7280);max-width:680px;}
+  .blog-hero .badge{background:#111;color:#fff;border-radius:999px;padding:.5rem 1.1rem;font-weight:600;letter-spacing:.02em;}
+  .blog-hero h1{color:var(--ink,#0b1120);}
+
+  .blog-section{padding:64px 0;background:#ffffff;}
+  .blog-card{
+    background:var(--panel,#ffffff);
+    border:1px solid var(--line,#e6e7eb);
+    border-radius:18px;
+    padding:24px;
+    height:100%;
+    display:flex;
+    flex-direction:column;
+    position:relative;
+    box-shadow:0 12px 32px rgba(15,23,42,.08);
+    transition:transform .25s ease, box-shadow .25s ease, border-color .25s ease;
+  }
+  .blog-card:hover{transform:translateY(-6px);box-shadow:0 18px 45px rgba(15,23,42,.12);border-color:#d8dae2;}
+  .blog-card__meta{color:var(--muted,#6b7280);font-size:.9rem;margin-bottom:12px;display:flex;align-items:center;gap:.5rem;}
+  .blog-card__title{font-size:1.3rem;margin-bottom:.75rem;font-weight:700;color:var(--ink,#0b1120);}
+  .blog-card__title a{color:inherit;text-decoration:none;}
+  .blog-card__title a:hover{text-decoration:underline;}
+  .blog-card__excerpt{color:var(--muted,#6b7280);margin-bottom:1.4rem;line-height:1.6;}
+  .blog-card__footer{margin-top:auto;font-weight:600;display:inline-flex;align-items:center;gap:.4rem;color:#0f172a;}
+  .blog-card__footer .bi{transition:transform .2s ease;}
+  .blog-card:hover .blog-card__footer .bi{transform:translateX(4px);}
+
+  .blog-pagination{display:flex;flex-direction:column;align-items:center;gap:8px;margin-top:48px;}
+  .blog-pagination .pager-summary{color:var(--muted,#6b7280);font-size:.9rem;}
+  .blog-pagination .pagination{gap:10px;}
+  .blog-pagination .page-link{border-radius:12px;border:1px solid var(--line,#e6e7eb);color:#111;padding:.55rem 1rem;box-shadow:0 2px 6px rgba(15,23,42,.06);font-weight:600;}
+  .blog-pagination .page-item.active .page-link{background:#111;border-color:#111;color:#fff;}
+  .blog-pagination .page-link:hover{background:#f4f5f8;}
+
+  .blog-empty{padding:80px 0;text-align:center;color:var(--muted,#6b7280);font-size:1.05rem;}
+
+  .blog-breadcrumb{color:var(--muted,#6b7280);font-size:.95rem;display:flex;gap:.5rem;flex-wrap:wrap;align-items:center;}
+  .blog-breadcrumb a{color:#0f172a;text-decoration:none;font-weight:500;}
+  .blog-breadcrumb a:hover{text-decoration:underline;}
+
+  .blog-meta{color:var(--muted,#6b7280);font-size:.95rem;display:flex;gap:.6rem;align-items:center;flex-wrap:wrap;}
+  .blog-meta .dot{width:6px;height:6px;border-radius:999px;background:var(--muted,#6b7280);display:inline-block;}
+
+  .blog-content{background:var(--panel,#ffffff);border-radius:20px;border:1px solid var(--line,#e6e7eb);padding:32px;box-shadow:0 20px 45px rgba(15,23,42,.08);}
+  .blog-content p{font-size:1.08rem;line-height:1.75;color:var(--ink,#111827);margin-bottom:1.2rem;}
+  .blog-content h2,.blog-content h3,.blog-content h4{color:#0f172a;font-weight:700;margin-top:2rem;margin-bottom:1rem;}
+  .blog-content ul,.blog-content ol{margin-bottom:1.2rem;padding-left:1.3rem;}
+  .blog-content li{margin-bottom:.5rem;}
+  .blog-content a{color:#111;text-decoration:underline;}
+  .blog-content blockquote{border-left:4px solid #111;padding-left:1rem;color:#0f172a;font-style:italic;margin:1.5rem 0;}
+  .blog-back{display:inline-flex;align-items:center;gap:.45rem;margin-top:24px;font-weight:600;color:#0f172a;text-decoration:none;}
+  .blog-back:hover{text-decoration:underline;}
+
+  .blog-related h5{font-weight:700;margin-bottom:1rem;color:#0f172a;}
+  .blog-related .blog-card{box-shadow:0 10px 28px rgba(15,23,42,.07);padding:20px;}
+  .blog-related .blog-card__title{font-size:1.05rem;margin-bottom:.5rem;}
+
+  @media (max-width: 768px){
+    .blog-hero{padding:56px 0 32px;text-align:center;}
+    .blog-content{padding:24px;}
+  }
+</style>
+@endpush

--- a/resources/views/blog/show.blade.php
+++ b/resources/views/blog/show.blade.php
@@ -1,0 +1,70 @@
+@extends('layouts.app')
+
+@section('title', $post->title . ' - OneLinkPDF Blog')
+
+@include('blog.partials.styles')
+
+@section('content')
+<section class="blog-hero">
+  <div class="container">
+    <div class="row g-4">
+      <div class="col-xl-9">
+        <nav class="blog-breadcrumb mb-3" aria-label="Breadcrumb">
+          <a href="{{ route('home') }}">Home</a>
+          <i class="bi bi-chevron-right"></i>
+          <a href="{{ route('blog.index') }}">Blog</a>
+          <i class="bi bi-chevron-right"></i>
+          <span aria-current="page">{{ $post->title }}</span>
+        </nav>
+        <span class="badge mb-3">Article</span>
+        <h1 class="display-5 fw-bold mb-3">{{ $post->title }}</h1>
+        <div class="blog-meta">
+          <span><i class="bi bi-calendar3 me-1"></i>{{ $post->published_at?->format('F j, Y') ?? $post->created_at?->format('F j, Y') }}</span>
+          @if ($post->updated_at && ($post->published_at ? $post->updated_at->gt($post->published_at) : $post->updated_at->gt($post->created_at)))
+            <span class="dot"></span>
+            <span>Updated {{ $post->updated_at->diffForHumans() }}</span>
+          @endif
+        </div>
+        @if ($post->excerpt)
+          <p class="lead mt-3">{{ $post->excerpt }}</p>
+        @endif
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="blog-section">
+  <div class="container">
+    <div class="row g-5">
+      <div class="col-lg-8">
+        <article class="blog-content">
+          {!! nl2br(e($post->content)) !!}
+        </article>
+        <a href="{{ route('blog.index') }}" class="blog-back"><i class="bi bi-arrow-left"></i> Back to blog</a>
+      </div>
+      <div class="col-lg-4">
+        @if ($relatedPosts->count())
+          <div class="blog-related">
+            <h5>More stories</h5>
+            @foreach ($relatedPosts as $related)
+              <article class="blog-card mb-3">
+                <div class="blog-card__meta">
+                  <i class="bi bi-calendar3"></i>
+                  <span>{{ $related->published_at?->format('M j, Y') ?? $related->created_at?->format('M j, Y') }}</span>
+                </div>
+                <h3 class="blog-card__title">
+                  <a href="{{ route('blog.show', $related->slug) }}">{{ $related->title }}</a>
+                </h3>
+                <p class="blog-card__excerpt">{{ $related->excerpt ?: \Illuminate\Support\Str::limit(strip_tags($related->content), 110) }}</p>
+                <div class="blog-card__footer">
+                  Read more <i class="bi bi-arrow-right"></i>
+                </div>
+              </article>
+            @endforeach
+          </div>
+        @endif
+      </div>
+    </div>
+  </div>
+</section>
+@endsection

--- a/resources/views/layouts/partials/footer.blade.php
+++ b/resources/views/layouts/partials/footer.blade.php
@@ -24,6 +24,7 @@
           <li><a href="{{ url('/features') }}">Features</a></li>
           <li><a href="{{ url('/pricing') }}">Pricing</a></li>
           <li><a href="{{ url('/how-it-works') }}">How It Works</a></li>
+          <li><a href="{{ url('/blog') }}">Blog</a></li>
         </ul>
       </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Admin\BlogController as AdminBlogController;
 use App\Http\Controllers\Admin\DashboardController as AdminDashboardController;
 use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Admin\UserPlanController as AdminUserPlanController;
@@ -9,6 +10,7 @@ use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\ContactController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\LeadCaptureController;
+use App\Http\Controllers\BlogController as PublicBlogController;
 use App\Http\Controllers\SitemapController;
 use App\Http\Controllers\NewsletterSubscriptionController;
 use App\Http\Controllers\PartnershipsController;
@@ -55,6 +57,8 @@ Route::get('/privacy', [HomeController::class, 'privacy'])->name('privacy');
 Route::get('/refund-policy', [HomeController::class, 'refundPolicy'])->name('refund-policy');
 Route::get('/docs', [HomeController::class, 'docs'])->name('docs');
 Route::get('/integrations', [HomeController::class, 'integrations'])->name('integrations');
+Route::get('/blog', [PublicBlogController::class, 'index'])->name('blog.index');
+Route::get('/blog/{slug}', [PublicBlogController::class, 'show'])->name('blog.show');
 Route::post('/subscribe', [NewsletterSubscriptionController::class, 'store'])->name('subscribe');
 Route::get('/sitemap.xml', [SitemapController::class, 'index'])->name('sitemap');
 
@@ -123,6 +127,7 @@ Route::prefix('admin')->middleware(['auth', 'admin'])->name('admin.')->group(fun
     Route::get('users/{user}/files/list', [AdminUserController::class, 'filesList'])->name('users.files.list');
     Route::post('users/{user}/files/generate-link', [AdminUserController::class, 'generateLink'])->name('users.files.generate');
     Route::get('user-plans', [AdminUserPlanController::class, 'index'])->name('user-plans.index');
+    Route::resource('blogs', AdminBlogController::class)->except(['show']);
 });
 
 /* ------------------------- Public viewer (no auth) ------------------------- */


### PR DESCRIPTION
## Summary
- add a `blog_posts` table and Eloquent model to store published articles
- build an admin CRUD experience for blog posts with create, edit, list, and delete views
- expose public blog index and detail pages and link them from routes, sitemap, and the site footer

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68c85508a9c883278ecd2e8145ce818b