### PR TITLE
Store blog featured images under public uploads

### DIFF
--- a/app/Models/BlogPost.php
+++ b/app/Models/BlogPost.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class BlogPost extends Model
 {
@@ -74,6 +75,10 @@ class BlogPost extends Model
             return null;
         }
 
-        return Storage::disk('public')->url($this->featured_image_path);
+        $disk = Str::startsWith($this->featured_image_path, ['uploads/', 'uploads\\'])
+            ? 'public_assets'
+            : 'public';
+
+        return Storage::disk($disk)->url($this->featured_image_path);
     }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -47,6 +47,15 @@ return [
             'report' => false,
         ],
 
+        'public_assets' => [
+            'driver' => 'local',
+            'root' => public_path(),
+            'url' => env('APP_URL'),
+            'visibility' => 'public',
+            'throw' => false,
+            'report' => false,
+        ],
+
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),


### PR DESCRIPTION
## Summary
- add a filesystem disk that targets the public directory so uploads can live under public/uploads
- save admin blog featured images into the uploads/blogs folder, ensuring the directory exists, and clean up the previous file when replaced or deleted
- generate featured image URLs from the correct disk for both legacy and new uploads

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68c86d45868c832783ca433b2c33445c