### PR TITLE
Refactor auth pages to external assets

### DIFF
--- a/public/assets/assets-auth/css/auth-style.css
+++ b/public/assets/assets-auth/css/auth-style.css
@@ -1,0 +1,237 @@
+:root {
+  --ink: #0a0a0a;
+  --muted: #6b7280;
+  --line: #e6e7eb;
+  --panel: #ffffff;
+  --radius: 14px;
+  --shadow: 0 6px 24px rgba(0, 0, 0, .20);
+  --shadow-lg: 0 16px 40px rgba(0, 0, 0, .35);
+}
+
+* {
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif;
+}
+
+body.auth-page {
+  background: #000;
+  color: var(--ink);
+  min-height: 100vh;
+}
+
+.auth-page .card-container {
+  width: 100%;
+  max-width: 560px;
+  margin: 0 auto;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-lg);
+  padding: 2.25rem;
+  animation: fadeIn .6s ease;
+}
+
+.login-page .card-container {
+  max-width: 520px;
+}
+
+.auth-page h3 {
+  font-weight: 700;
+}
+
+.auth-page a {
+  color: #111;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.auth-page a:hover {
+  opacity: .85;
+}
+
+.auth-page .form-label {
+  font-weight: 600;
+}
+
+.auth-page .form-control,
+.auth-page .form-select {
+  border-radius: 12px;
+  border: 1px solid var(--line);
+}
+
+.register-page .form-control,
+.register-page .form-select {
+  padding: 1rem 1rem;
+  height: calc(3.5rem + 2px);
+  transition: all .2s ease;
+}
+
+.auth-page .form-control:focus,
+.auth-page .form-select:focus {
+  border-color: #111;
+  box-shadow: 0 0 0 .2rem rgba(17, 17, 17, .08);
+}
+
+.auth-page .is-invalid {
+  border-color: #dc2626 !important;
+}
+
+.auth-page .error-message {
+  color: #dc2626;
+  font-size: .875rem;
+  margin-top: .25rem;
+  min-height: 1rem;
+}
+
+.auth-page .with-icon {
+  position: relative;
+}
+
+.auth-page .with-icon .fi {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #9ca3af;
+  z-index: 3;
+  pointer-events: none;
+  font-size: 1.1rem;
+}
+
+.auth-page .with-icon .form-control,
+.auth-page .with-icon .form-select {
+  padding-left: 2.6rem;
+}
+
+.auth-page .with-icon > label {
+  padding-left: 2.6rem;
+  color: var(--muted);
+}
+
+.auth-page .password-floating .form-control {
+  padding-right: 2.25rem;
+}
+
+.auth-page .password-floating .toggle-password {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  cursor: pointer;
+  color: #9ca3af;
+  z-index: 3;
+}
+
+.auth-page .password-floating .toggle-password:hover {
+  color: #111;
+}
+
+.auth-page .btn-primary {
+  background: #111;
+  border-color: #111;
+  font-weight: 700;
+  border-radius: 12px;
+  transition: transform .12s ease, box-shadow .12s ease, background .12s ease;
+}
+
+.auth-page .btn-primary:hover {
+  background: #000;
+  border-color: #000;
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.register-page .form-check-input {
+  border-radius: 6px;
+}
+
+.register-page .form-check-input:focus {
+  box-shadow: 0 0 0 .2rem rgba(17, 17, 17, .08);
+  border-color: #111;
+}
+
+.register-page .form-check-input:checked {
+  background-color: #111;
+  border-color: #111;
+}
+
+.register-page #password-strength {
+  margin-top: 8px;
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+}
+
+.register-page .progress {
+  height: 8px;
+  background: #f1f1f1;
+  flex: 1;
+}
+
+.register-page .progress-bar {
+  background: #111 !important;
+}
+
+.register-page #strength-text {
+  color: #6b7280;
+  min-width: 64px;
+  text-align: right;
+}
+
+.register-page .free-pill {
+  display: inline-block;
+  padding: .45rem 1rem;
+  border-radius: 9999px;
+  background: #dcfce7;
+  color: #14532d;
+  border: 1px solid #bbf7d0;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.register-page .free-pill-wrapper {
+  text-align: center;
+  margin: .75rem 0 1.25rem 0;
+}
+
+.auth-page .toast-container {
+  z-index: 1080;
+}
+
+.login-page .toplinks a {
+  color: #f5f5f5;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.login-page .toplinks a .bi {
+  vertical-align: -2px;
+}
+
+.login-page .toplinks a:hover {
+  opacity: .85;
+  text-decoration: underline;
+}
+
+.register-page .form-select {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%230a0a0a' viewBox='0 0 16 16'%3E%3Cpath d='M8 12L2 6h12L8 12z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 1rem center;
+  background-size: 16px 12px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  padding-right: 2.5rem;
+  cursor: pointer;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/public/assets/assets-auth/js/auth-main.js
+++ b/public/assets/assets-auth/js/auth-main.js
@@ -1,0 +1,492 @@
+(function () {
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+
+  const toastIcons = {
+    primary: 'info-circle',
+    success: 'check-circle',
+    danger: 'exclamation-octagon',
+    warning: 'exclamation-triangle',
+    info: 'info-circle',
+    dark: 'bell',
+    light: 'bell'
+  };
+
+  function showToast(message, options = {}) {
+    const {
+      title = 'Notice',
+      variant = 'primary',
+      delayMs = 4000,
+      onClick = null
+    } = options;
+
+    const container = document.getElementById('bsToasts');
+    if (!container || typeof bootstrap === 'undefined' || !bootstrap.Toast) {
+      return;
+    }
+
+    const icon = toastIcons[variant] || toastIcons.primary;
+    const toast = document.createElement('div');
+    toast.className = `toast text-bg-${variant} border-0 shadow`;
+    toast.setAttribute('role', 'alert');
+    toast.setAttribute('aria-live', 'assertive');
+    toast.setAttribute('aria-atomic', 'true');
+
+    const headerClass = variant === 'light' ? '' : `text-bg-${variant}`;
+    toast.innerHTML = `
+      <div class="toast-header ${headerClass}">
+        <i class="bi bi-${icon} me-2"></i>
+        <strong class="me-auto">${title}</strong>
+        <small class="opacity-75">now</small>
+        <button type="button" class="btn-close ${variant === 'light' ? '' : 'btn-close-white'} ms-2 mb-1" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+      <div class="toast-body">${message}</div>
+    `;
+
+    if (typeof onClick === 'function') {
+      toast.style.cursor = 'pointer';
+      toast.addEventListener('click', (event) => {
+        if (!event.target.classList.contains('btn-close')) {
+          onClick();
+        }
+      });
+    }
+
+    container.appendChild(toast);
+    const instance = new bootstrap.Toast(toast, { autohide: true, delay: delayMs });
+    instance.show();
+    toast.addEventListener('hidden.bs.toast', () => toast.remove());
+  }
+
+  function setupPasswordToggles() {
+    document.querySelectorAll('.password-floating').forEach((group) => {
+      const toggle = group.querySelector('.toggle-password');
+      const input = group.querySelector('input');
+      if (!toggle || !input) {
+        return;
+      }
+
+      const togglePassword = () => {
+        const isPassword = input.getAttribute('type') === 'password';
+        input.setAttribute('type', isPassword ? 'text' : 'password');
+        toggle.classList.toggle('bi-eye');
+        toggle.classList.toggle('bi-eye-slash');
+      };
+
+      toggle.addEventListener('click', togglePassword);
+      toggle.addEventListener('keypress', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          togglePassword();
+        }
+      });
+    });
+  }
+
+  function initLoginForm() {
+    const loginForm = document.getElementById('loginForm');
+    if (!loginForm) {
+      return;
+    }
+
+    const emailError = document.getElementById('email_error');
+    const passwordError = document.getElementById('password_error');
+    const redirectUrl = loginForm.dataset.redirect || '';
+    const homeUrl = document.body?.dataset?.homeUrl;
+
+    if (homeUrl) {
+      document.addEventListener('keydown', (event) => {
+        const key = event.key || '';
+        if (key === 'Escape' || (event.altKey && key.toLowerCase() === 'h')) {
+          window.location = homeUrl;
+        }
+      });
+    }
+
+    loginForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+
+      [emailError, passwordError].forEach((el) => {
+        if (el) {
+          el.textContent = '';
+        }
+      });
+      loginForm.querySelectorAll('.form-control').forEach((input) => input.classList.remove('is-invalid'));
+
+      const emailInput = loginForm.querySelector('input[name="email"]');
+      const passwordInput = loginForm.querySelector('input[name="password"]');
+
+      let valid = true;
+      const email = emailInput?.value.trim();
+      const password = passwordInput?.value || '';
+
+      if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+        if (emailError) {
+          emailError.textContent = 'A valid email is required.';
+        }
+        if (emailInput) {
+          emailInput.classList.add('is-invalid');
+        }
+        valid = false;
+      }
+
+      if (!password) {
+        if (passwordError) {
+          passwordError.textContent = 'Password is required.';
+        }
+        if (passwordInput) {
+          passwordInput.classList.add('is-invalid');
+        }
+        valid = false;
+      }
+
+      if (!valid) {
+        showToast('Please correct the errors above.', {
+          title: 'Validation Error',
+          variant: 'danger'
+        });
+        return;
+      }
+
+      const actionUrl = loginForm.getAttribute('action') || loginForm.dataset.action;
+      if (!actionUrl) {
+        return;
+      }
+
+      const formData = new FormData(loginForm);
+
+      try {
+        const response = await fetch(actionUrl, {
+          method: 'POST',
+          headers: csrfToken ? { 'X-CSRF-TOKEN': csrfToken } : {},
+          body: formData
+        });
+
+        let result = {};
+        try {
+          result = await response.json();
+        } catch (error) {
+          result = {};
+        }
+
+        if (response.ok && result.success) {
+          showToast('Login successful. Redirecting...', {
+            title: 'Success',
+            variant: 'success'
+          });
+
+          const target = result.redirect || redirectUrl;
+          if (target) {
+            setTimeout(() => {
+              window.location = target;
+            }, 1000);
+          }
+        } else {
+          showToast(result.error || 'Login failed.', {
+            title: 'Error',
+            variant: 'danger'
+          });
+        }
+      } catch (error) {
+        showToast('Something went wrong. Please try again.', {
+          title: 'Error',
+          variant: 'danger'
+        });
+      }
+    });
+  }
+
+  function initRegisterForm() {
+    const registerForm = document.getElementById('registerForm');
+    if (!registerForm) {
+      return;
+    }
+
+    const storeUrl = registerForm.dataset.storeUrl;
+    const captchaUrl = registerForm.dataset.captchaUrl;
+    const loginUrl = registerForm.dataset.loginUrl;
+
+    const countrySelect = document.getElementById('country');
+    const planSelect = document.getElementById('plan');
+
+    const setError = (inputId, errorId, message) => {
+      const input = document.getElementById(inputId);
+      const error = document.getElementById(errorId);
+      if (input) {
+        input.classList.add('is-invalid');
+      }
+      if (error) {
+        error.textContent = message || '';
+      }
+    };
+
+    const clearErrors = () => {
+      registerForm.querySelectorAll('.error-message').forEach((el) => {
+        el.textContent = '';
+      });
+      registerForm.querySelectorAll('.form-control, .form-select, .form-check-input').forEach((el) => {
+        el.classList.remove('is-invalid');
+      });
+    };
+
+    const updatePlanOptions = () => {
+      if (!planSelect) {
+        return;
+      }
+
+      const hasCountry = countrySelect && countrySelect.value.trim() !== '';
+      planSelect.disabled = !hasCountry;
+      planSelect.setAttribute('aria-disabled', planSelect.disabled ? 'true' : 'false');
+
+      if (!hasCountry) {
+        planSelect.value = '';
+        planSelect.classList.remove('is-invalid');
+        const planError = document.getElementById('plan_id_error');
+        if (planError) {
+          planError.textContent = '';
+        }
+      }
+
+      let iso = '';
+      let countryValue = '';
+      if (hasCountry && countrySelect) {
+        const selectedOption = countrySelect.options[countrySelect.selectedIndex];
+        if (selectedOption && selectedOption.dataset && selectedOption.dataset.iso) {
+          iso = selectedOption.dataset.iso.toUpperCase();
+        }
+        countryValue = countrySelect.value.trim().toLowerCase();
+      }
+
+      const isIndia = iso === 'IN' || countryValue.includes('india');
+      const locale = isIndia ? 'en-IN' : 'en-US';
+      const currency = isIndia ? 'INR' : 'USD';
+
+      planSelect.querySelectorAll('option[data-plan]').forEach((option) => {
+        const name = option.dataset.name || option.textContent;
+        const billing = option.dataset.billing || '';
+        const priceValue = isIndia ? option.dataset.inrPrice : option.dataset.usdPrice;
+        const priceNumber = parseFloat(priceValue);
+
+        let suffix = '';
+        if (billing === 'month') {
+          suffix = '/month';
+        } else if (billing === 'year') {
+          suffix = '/year';
+        }
+
+        if (Number.isFinite(priceNumber) && priceNumber > 0) {
+          const hasCents = Math.abs(priceNumber - Math.round(priceNumber)) > 0.001;
+          const digits = hasCents ? 2 : 0;
+          const formatter = new Intl.NumberFormat(locale, {
+            style: 'currency',
+            currency,
+            minimumFractionDigits: digits,
+            maximumFractionDigits: digits
+          });
+          option.textContent = `${name} - ${formatter.format(priceNumber)}${suffix}`;
+        } else {
+          option.textContent = `${name} - Free`;
+        }
+      });
+    };
+
+    if (countrySelect) {
+      countrySelect.addEventListener('change', updatePlanOptions);
+    }
+    updatePlanOptions();
+
+    const refreshButton = document.getElementById('refreshCaptcha');
+    if (refreshButton && captchaUrl) {
+      refreshButton.addEventListener('click', async () => {
+        try {
+          const response = await fetch(captchaUrl, {
+            method: 'POST',
+            headers: csrfToken ? { 'X-CSRF-TOKEN': csrfToken } : {}
+          });
+          const json = await response.json();
+          if (json && json.captcha_a && json.captcha_b) {
+            const label = document.getElementById('captcha_label');
+            if (label) {
+              label.textContent = `What is ${json.captcha_a} + ${json.captcha_b}?`;
+            }
+            const input = document.getElementById('captcha');
+            if (input) {
+              input.value = '';
+            }
+          }
+        } catch (error) {
+          // ignore refresh failures
+        }
+      });
+    }
+
+    registerForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      clearErrors();
+
+      const data = new FormData(registerForm);
+      let valid = true;
+
+      if (!data.get('first_name')) {
+        setError('firstName', 'first_name_error', 'First name is required.');
+        valid = false;
+      }
+      if (!data.get('last_name')) {
+        setError('lastName', 'last_name_error', 'Last name is required.');
+        valid = false;
+      }
+      if (!data.get('country')) {
+        setError('country', 'country_error', 'Country is required.');
+        valid = false;
+      }
+      if (!data.get('company')) {
+        setError('company', 'company_error', 'Company is required.');
+        valid = false;
+      }
+
+      const isPlanDisabled = planSelect ? planSelect.disabled : false;
+      if (!isPlanDisabled && !data.get('plan_id')) {
+        setError('plan', 'plan_id_error', 'Plan is required.');
+        valid = false;
+      }
+
+      const email = data.get('email');
+      if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
+        setError('email', 'email_error', 'A valid email is required.');
+        valid = false;
+      }
+
+      const password = data.get('password');
+      if (!password || password.length < 6) {
+        setError('password', 'password_error', 'Password must be at least 6 characters.');
+        valid = false;
+      }
+
+      if (!data.get('agreed_terms')) {
+        setError('terms', 'agreed_terms_error', 'You must agree to the terms.');
+        valid = false;
+      }
+
+      if (!data.get('captcha')) {
+        setError('captcha', 'captcha_error', 'Captcha is required.');
+        valid = false;
+      }
+
+      if (!valid) {
+        showToast('Please correct the errors above.', {
+          title: 'Validation Error',
+          variant: 'danger'
+        });
+        return;
+      }
+
+      if (!storeUrl) {
+        return;
+      }
+
+      try {
+        const response = await fetch(storeUrl, {
+          method: 'POST',
+          headers: Object.assign({}, csrfToken ? { 'X-CSRF-TOKEN': csrfToken } : {}, { Accept: 'application/json' }),
+          body: data
+        });
+
+        let result = {};
+        try {
+          result = await response.json();
+        } catch (error) {
+          result = {};
+        }
+
+        if (response.status === 422) {
+          const fieldMap = {
+            first_name: 'firstName',
+            last_name: 'lastName',
+            country: 'country',
+            company: 'company',
+            plan_id: 'plan',
+            email: 'email',
+            password: 'password',
+            agreed_terms: 'terms',
+            captcha: 'captcha'
+          };
+
+          Object.entries(result.errors || {}).forEach(([field, messages]) => {
+            const inputId = fieldMap[field] || field;
+            const message = Array.isArray(messages) ? messages[0] : messages;
+            setError(inputId, `${field}_error`, message);
+          });
+
+          showToast('Please correct the errors above.', {
+            title: 'Validation Error',
+            variant: 'danger'
+          });
+          return;
+        }
+
+        if (response.ok && result.success) {
+          showToast('Registration successful. Redirecting to login...', {
+            title: 'Success',
+            variant: 'success'
+          });
+          if (loginUrl) {
+            setTimeout(() => {
+              window.location = loginUrl;
+            }, 1200);
+          }
+        } else {
+          const message = result.error || 'Registration failed.';
+          showToast(message, {
+            title: 'Error',
+            variant: 'danger'
+          });
+
+          if (loginUrl && (message || '').toLowerCase().includes('email')) {
+            showToast('Already have an account? Click here to log in.', {
+              title: 'Login',
+              variant: 'info',
+              delayMs: 4000,
+              onClick: () => {
+                window.location = loginUrl;
+              }
+            });
+          }
+        }
+      } catch (error) {
+        showToast('Something went wrong. Please try again.', {
+          title: 'Error',
+          variant: 'danger'
+        });
+      }
+    });
+
+    const passwordInput = document.getElementById('password');
+    const strengthWrapper = document.getElementById('password-strength');
+    const strengthBar = strengthWrapper ? strengthWrapper.querySelector('.progress-bar') : null;
+    const strengthText = document.getElementById('strength-text');
+
+    if (passwordInput && strengthBar && strengthText) {
+      passwordInput.addEventListener('input', () => {
+        const value = passwordInput.value || '';
+        let score = 0;
+        if (value.length >= 8) {
+          score += 25;
+        }
+        if (/[A-Z]/.test(value)) {
+          score += 25;
+        }
+        if (/[0-9]/.test(value)) {
+          score += 25;
+        }
+        if (/[!@#\$%\^&\*]/.test(value)) {
+          score += 25;
+        }
+        strengthBar.style.width = `${score}%`;
+        strengthText.textContent = !value ? '' : (score < 50 ? 'Weak' : (score < 100 ? 'Medium' : 'Strong'));
+      });
+    }
+  }
+
+  setupPasswordToggles();
+  initLoginForm();
+  initRegisterForm();
+})();

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -20,70 +20,13 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
 
-  <!-- Page CSS (Monochrome, black background) -->
-  <style>
-    :root{
-      --ink:#0a0a0a; --muted:#6b7280; --line:#e6e7eb; --panel:#ffffff;
-      --radius:14px; --shadow:0 6px 24px rgba(0,0,0,.20); --shadow-lg:0 16px 40px rgba(0,0,0,.35);
-    }
-    *{ font-family:'Inter',system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif; }
-    body{ background:#000; color:var(--ink); min-height:100vh; }
-
-    .card-container{
-      max-width:520px; margin:0 auto; background:var(--panel);
-      border:1px solid var(--line); border-radius:var(--radius);
-      box-shadow:var(--shadow-lg); padding:2.25rem; animation:fadeIn .6s ease;
-    }
-
-    h3{ font-weight:700; }
-    a{ color:#111; text-decoration:underline; text-underline-offset:2px; }
-    a:hover{ opacity:.85; }
-
-    .form-label{ font-weight:600; }
-    .form-control{ border-radius:12px; border:1px solid var(--line); }
-    .form-control:focus{ border-color:#111; box-shadow:0 0 0 .2rem rgba(255,255,255,.08); }
-    .is-invalid{ border-color:#dc2626 !important; }
-
-    .btn-primary{
-      background:#111; border-color:#111; font-weight:700; border-radius:12px;
-      transition:transform .12s ease, box-shadow .12s ease, background .12s ease;
-    }
-    .btn-primary:hover{ background:#000; border-color:#000; transform:translateY(-1px); box-shadow:var(--shadow); }
-
-    /* LEFT icons inside floating controls */
-    .with-icon{ position:relative; }
-    .with-icon .fi{
-      position:absolute; left:12px; top:50%; transform:translateY(-50%);
-      color:#9ca3af; z-index:3; pointer-events:none; font-size:1.1rem;
-    }
-    /* make space for icon in floating inputs */
-    .with-icon .form-control{ padding-left:2.6rem; }
-    .with-icon label{ padding-left:2.6rem; color:var(--muted); }
-
-    /* Password: left lock + right eye */
-    .password-floating .form-control{ padding-right:2.25rem; }
-    .password-floating .toggle-password{
-      position:absolute; right:12px; top:50%; transform:translateY(-50%);
-      cursor:pointer; color:#9ca3af; z-index:3;
-    }
-    .password-floating .toggle-password:hover{ color:#111; }
-
-    .error-message{ color:#dc2626; font-size:.875rem; margin-top:.25rem; min-height:1rem; }
-    .toast-container{ z-index:1080; }
-    .toast .toast-header .bi{ font-size:1rem; }
-
-    .toplinks a{ color:#f5f5f5; text-decoration:none; font-weight:600; }
-    .toplinks a .bi{ vertical-align:-2px; }
-    .toplinks a:hover{ opacity:.85; text-decoration:underline; }
-
-    @keyframes fadeIn{ from{opacity:0; transform:translateY(12px);} to{opacity:1; transform:none;} }
-  </style>
+  <link rel="stylesheet" href="{{ asset('assets/assets-auth/css/auth-style.css') }}">
 </head>
-<body class="d-flex align-items-center min-vh-100">
+<body class="auth-page login-page d-flex align-items-center min-vh-100" data-home-url="{{ url('/') }}">
   <div class="container py-5">
     <!-- Back to website (top) -->
     <div class="toplinks mb-3 text-center">
-      <a id="backHomeTop" href="#" title="Go to main website (Esc or Alt+H)">
+      <a id="backHomeTop" href="{{ url('/') }}" title="Go to main website (Esc or Alt+H)">
         <i class="bi bi-arrow-left-circle me-1"></i> Back to Website
       </a>
     </div>
@@ -92,7 +35,7 @@
       <h3 class="text-center mb-3">Login</h3>
       <p class="text-center text-muted mb-4">Welcome back — enter your credentials to continue.</p>
 
-      <form id="loginForm" novalidate>
+      <form id="loginForm" method="POST" action="{{ route('login') }}" novalidate data-redirect="{{ url('/vendor/dashboard') }}">
         @csrf
 
         <!-- Email with left icon -->
@@ -117,12 +60,12 @@
         </div>
 
         <div class="text-center mt-3">
-          <a id="forgotPasswordLink" href="#" class="text-decoration-underline">Forgot password?</a>
+          <a id="forgotPasswordLink" href="{{ url('/forgot-password') }}" class="text-decoration-underline">Forgot password?</a>
         </div>
 
         <div class="text-center mt-3">
           <span class="text-muted">Don’t have an account?</span>
-          <a id="registerLink" href="#" class="fw-semibold">Create one</a>
+          <a id="registerLink" href="{{ route('register') }}" class="fw-semibold">Create one</a>
         </div>
       </form>
 
@@ -136,94 +79,6 @@
   <!-- Scripts -->
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-
-  <script>
-    const BASE = "{{ url('/') }}";
-    document.getElementById('registerLink').href = BASE + '/register';
-    document.getElementById('forgotPasswordLink').href = BASE + '/forgot-password';
-    document.getElementById('backHomeTop').href = BASE + '/';
-
-    document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' || (e.altKey && (e.key.toLowerCase?.() === 'h'))) {
-        window.location = BASE + '/';
-      }
-    });
-
-    function showToast(message, title='Notice', variant='primary', delayMs=4000){
-      const container = document.getElementById('bsToasts');
-      const iconMap = { primary:'info-circle', success:'check-circle', danger:'exclamation-octagon',
-                        warning:'exclamation-triangle', info:'info-circle', dark:'bell', light:'bell' };
-      const icon = iconMap[variant] || 'info-circle';
-      const el = document.createElement('div');
-      el.className = `toast text-bg-${variant} border-0 shadow`;
-      el.setAttribute('role','alert'); el.setAttribute('aria-live','assertive'); el.setAttribute('aria-atomic','true');
-      el.innerHTML = `
-        <div class="toast-header ${variant==='light'?'':'text-bg-'+variant}">
-          <i class="bi bi-${icon} me-2"></i>
-          <strong class="me-auto">${title}</strong>
-          <small class="opacity-75">now</small>
-          <button type="button" class="btn-close ${variant==='light'?'':'btn-close-white'} ms-2 mb-1" data-bs-dismiss="toast" aria-label="Close"></button>
-        </div>
-        <div class="toast-body">${message}</div>`;
-      container.appendChild(el);
-      const t = new bootstrap.Toast(el, { autohide:true, delay:delayMs }); t.show();
-      el.addEventListener('hidden.bs.toast', () => el.remove());
-    }
-
-    document.getElementById('loginForm').addEventListener('submit', async function(e){
-      e.preventDefault();
-      document.querySelectorAll('.error-message').forEach(el => el.textContent = '');
-      document.querySelectorAll('.form-control').forEach(el => el.classList.remove('is-invalid'));
-
-      const data = new FormData(e.target);
-      let valid = true;
-
-      const email = data.get('email');
-      const password = data.get('password');
-
-      if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
-        document.getElementById('email_error').textContent = 'A valid email is required.';
-        document.getElementById('email').classList.add('is-invalid');
-        valid = false;
-      }
-      if (!password) {
-        document.getElementById('password_error').textContent = 'Password is required.';
-        document.getElementById('password').classList.add('is-invalid');
-        valid = false;
-      }
-      if (!valid) { showToast('Please correct the errors above.','Validation Error','danger'); return; }
-
-      try{
-        const res = await fetch(BASE + '/login', {
-          method:'POST',
-          headers:{ 'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content') },
-          body:data
-        });
-        let result={}; try{ result=await res.json(); }catch(_){}
-        if(res.ok && result.success){
-          showToast('Login successful. Redirecting...','Success','success');
-          const redirect = result.redirect || (BASE + '/vendor/dashboard');
-          setTimeout(()=> window.location = redirect, 1000);
-        }else{
-          showToast(result.error || 'Login failed.','Error','danger');
-        }
-      }catch(_){
-        showToast('Something went wrong. Please try again.','Error','danger');
-      }
-    });
-
-    // Show/Hide password
-    (function(){
-      const toggle=document.getElementById('togglePassword');
-      const input=document.getElementById('password');
-      function togglePw(){
-        const type=input.getAttribute('type')==='password'?'text':'password';
-        input.setAttribute('type', type);
-        toggle.classList.toggle('bi-eye'); toggle.classList.toggle('bi-eye-slash');
-      }
-      toggle.addEventListener('click', togglePw);
-      toggle.addEventListener('keypress', (e)=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); togglePw(); }});
-    })();
-  </script>
+  <script src="{{ asset('assets/assets-auth/js/auth-main.js') }}"></script>
 </body>
 </html>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -21,91 +21,9 @@
 
   <meta name="csrf-token" content="{{ csrf_token() }}">
 
-  <!-- Page CSS -->
-  <style>
-    :root{
-      --ink:#0a0a0a; --muted:#6b7280; --line:#e6e7eb; --panel:#ffffff;
-      --radius:14px; --shadow-lg:0 16px 40px rgba(0,0,0,.35);
-    }
-    *{ font-family:'Inter',system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif; }
-    body{ background:#000; color:var(--ink); min-height:100vh; }
-
-    .card-container{
-      max-width:560px; margin:0 auto; background:var(--panel);
-      border:1px solid var(--line); border-radius:var(--radius);
-      box-shadow:var(--shadow-lg); padding:2.25rem; animation:fadeIn .6s ease;
-    }
-    h3{ font-weight:700; }
-    a{ color:#111; text-decoration:underline; text-underline-offset:2px; }
-    a:hover{ opacity:.85; }
-
-    .form-control,.form-select{
-      border-radius:12px; border:1px solid var(--line);
-      padding:1rem 1rem; height:calc(3.5rem + 2px); transition:all .2s ease;
-    }
-    .form-control:focus,.form-select:focus{ border-color:#111; box-shadow:0 0 0 .2rem rgba(0,0,0,.08); }
-    .is-invalid{ border-color:#dc2626 !important; }
-    .error-message{ color:#dc2626; font-size:.875rem; margin-top:.25rem; min-height:1rem; }
-
-    .with-icon{ position:relative; }
-    .with-icon .fi{
-      position:absolute; left:12px; top:50%; transform:translateY(-50%);
-      color:#9ca3af; z-index:3; pointer-events:none; font-size:1.1rem;
-    }
-    .with-icon .form-control,
-    .with-icon .form-select{ padding-left:2.6rem; }
-    .with-icon > label{ padding-left:2.6rem; color:var(--muted); }
-
-    .form-select{
-      background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%230a0a0a' viewBox='0 0 16 16'%3E%3Cpath d='M8 12L2 6h12L8 12z'/%3E%3C/svg%3E");
-      background-repeat:no-repeat; background-position:right 1rem center; background-size:16px 12px;
-      -webkit-appearance:none; -moz-appearance:none; appearance:none; padding-right:2.5rem; cursor:pointer;
-    }
-
-    .password-floating .form-control{ padding-right:2.25rem; }
-    .password-floating .toggle-password{
-      position:absolute; right:12px; top:50%; transform:translateY(-50%);
-      cursor:pointer; color:#9ca3af; z-index:3;
-    }
-    .password-floating .toggle-password:hover{ color:#111; }
-
-    .btn-primary{
-      background:#111; border-color:#111; font-weight:700; border-radius:12px;
-      transition:transform .12s ease, box-shadow .12s ease, background .12s ease;
-    }
-    .btn-primary:hover{ background:#000; border-color:#000; transform:translateY(-1px); }
-
-    .form-check-input{ border-radius:6px; }
-    .form-check-input:focus{ box-shadow:0 0 0 .2rem rgba(17,17,17,.08); border-color:#111; }
-    .form-check-input:checked{ background-color:#111; border-color:#111; }
-
-    #password-strength{ margin-top:8px; display:flex; align-items:center; gap:.5rem; }
-    .progress{ height:8px; background:#f1f1f1; flex:1; }
-    .progress-bar{ background:#111 !important; }
-    #strength-text{ color:#6b7280; min-width:64px; text-align:right; }
-
-    .toast-container{ z-index:1080; }
-    @keyframes fadeIn{ from{opacity:0; transform:translateY(12px);} to{opacity:1; transform:none;} }
-
-    /* Free-plan reassurance pill */
-    .free-pill{
-      display:inline-block;
-      padding:.45rem 1rem;
-      border-radius:9999px;
-      background:#dcfce7;
-      color:#14532d;
-      border:1px solid #bbf7d0;
-      font-weight:500;
-      font-size:12px;
-      line-height:1;
-    }
-    .free-pill-wrapper{
-      text-align:center;
-      margin:0.75rem 0 1.25rem 0;
-    }
-  </style>
+  <link rel="stylesheet" href="{{ asset('assets/assets-auth/css/auth-style.css') }}">
 </head>
-<body class="d-flex align-items-center min-vh-100">
+<body class="auth-page register-page d-flex align-items-center min-vh-100">
   <div class="container py-5">
     <div class="row justify-content-center">
       <div class="col-md-12">
@@ -118,7 +36,10 @@
             <span class="free-pill">No credit card or payment required for the Free plan</span>
           </div>
 
-          <form id="registerForm" novalidate>
+          <form id="registerForm" method="POST" novalidate
+                data-store-url="{{ route('register.store') }}"
+                data-captcha-url="{{ route('register.captcha') }}"
+                data-login-url="{{ route('login') }}">
             @csrf
             <div class="row g-3">
               <div class="col-md-6">
@@ -232,7 +153,6 @@
             <div class="mb-3">
               <label for="captcha" id="captcha_label" class="form-label">What is {{ $captcha_a }} + {{ $captcha_b }}?</label>
               <div class="input-group">
-                <!-- Removed the left icon addon -->
                 <input type="text" class="form-control" id="captcha" name="captcha" aria-label="Captcha">
                 <button type="button" class="btn btn-outline-secondary" id="refreshCaptcha" aria-label="Refresh captcha">
                   <i class="bi bi-arrow-clockwise"></i>
@@ -261,186 +181,6 @@
   <!-- Scripts -->
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
-
-  <script>
-    // Toast helper
-    function showToast(message, title='Notice', variant='primary', delayMs=4000, onClick=null){
-      const container=document.getElementById('bsToasts');
-      const icons={primary:'info-circle',success:'check-circle',danger:'exclamation-octagon',warning:'exclamation-triangle',info:'info-circle',dark:'bell',light:'bell'};
-      const icon=icons[variant]||'info-circle';
-      const el=document.createElement('div');
-      el.className=`toast text-bg-${variant} border-0 shadow`;
-      el.setAttribute('role','alert'); el.setAttribute('aria-live','assertive'); el.setAttribute('aria-atomic','true');
-      el.innerHTML=`
-        <div class="toast-header ${variant==='light'?'':'text-bg-'+variant}">
-          <i class="bi bi-${icon} me-2"></i>
-          <strong class="me-auto">${title}</strong>
-          <small class="opacity-75">now</small>
-          <button type="button" class="btn-close ${variant==='light'?'':'btn-close-white'} ms-2 mb-1" data-bs-dismiss="toast" aria-label="Close"></button>
-        </div>
-        <div class="toast-body">${message}</div>`;
-      if(typeof onClick==='function'){
-        el.style.cursor='pointer';
-        el.addEventListener('click',e=>{ if(!e.target.classList.contains('btn-close')) onClick(); });
-      }
-      container.appendChild(el);
-      const t=new bootstrap.Toast(el,{autohide:true,delay:delayMs}); t.show();
-      el.addEventListener('hidden.bs.toast',()=>el.remove());
-    }
-
-    // Validation helpers
-    function setErr(inputId, errorId, msg){
-      const i=document.getElementById(inputId), e=document.getElementById(errorId);
-      if(i) i.classList.add('is-invalid');
-      if(e) e.textContent = msg || '';
-    }
-    function clearAllErrors(){
-      document.querySelectorAll('.error-message').forEach(el=>el.textContent='');
-      document.querySelectorAll('.form-control, .form-select, .form-check-input').forEach(el=>el.classList.remove('is-invalid'));
-    }
-
-    const countrySelect=document.getElementById('country');
-    const planSelect=document.getElementById('plan');
-
-    // Dynamic INR/USD plan labels
-    function updatePlanOptions(){
-      if(!planSelect) return;
-
-      const hasCountry=countrySelect && countrySelect.value.trim()!=='';
-      planSelect.disabled=!hasCountry;
-      planSelect.setAttribute('aria-disabled', planSelect.disabled ? 'true' : 'false');
-      if(!hasCountry){
-        planSelect.value='';
-        planSelect.classList.remove('is-invalid');
-        const planError=document.getElementById('plan_id_error');
-        if(planError) planError.textContent='';
-      }
-
-      let iso='';
-      let countryValue='';
-      if(hasCountry && countrySelect){
-        const selectedOption=countrySelect.options[countrySelect.selectedIndex];
-        if(selectedOption && selectedOption.dataset && selectedOption.dataset.iso){
-          iso=selectedOption.dataset.iso.toUpperCase();
-        }
-        countryValue=countrySelect.value.trim().toLowerCase();
-      }
-      const isIndia = iso==='IN' || countryValue.includes('india');
-      const locale = isIndia ? 'en-IN' : 'en-US';
-      const currency = isIndia ? 'INR' : 'USD';
-
-      planSelect.querySelectorAll('option[data-plan]').forEach(function(option){
-        const name=option.dataset.name || option.textContent;
-        const billing=option.dataset.billing || '';
-        const priceValue=isIndia ? option.dataset.inrPrice : option.dataset.usdPrice;
-        const priceNumber=parseFloat(priceValue);
-        let suffix=''; if(billing==='month') suffix='/month'; else if(billing==='year') suffix='/year';
-        if(isFinite(priceNumber) && priceNumber>0){
-          const hasCents=Math.abs(priceNumber-Math.round(priceNumber))>0.001;
-          const digits=hasCents?2:0;
-          const formatted=priceNumber.toLocaleString(locale,{style:'currency',currency,minimumFractionDigits:digits,maximumFractionDigits:digits});
-          option.textContent=`${name} - ${formatted}${suffix}`;
-        }else{
-          option.textContent=`${name} - Free`;
-        }
-      });
-    }
-    if(countrySelect && planSelect){
-      countrySelect.addEventListener('change', updatePlanOptions);
-      document.addEventListener('DOMContentLoaded', updatePlanOptions);
-      updatePlanOptions();
-    }
-
-    // Captcha refresh
-    const refreshBtn=document.getElementById('refreshCaptcha');
-    if(refreshBtn){
-      refreshBtn.addEventListener('click', async ()=>{
-        try{
-          const res=await fetch(@json(route('register.captcha')),{
-            method:'POST',
-            headers:{'X-CSRF-TOKEN':document.querySelector('meta[name="csrf-token"]').getAttribute('content')}
-          });
-          const json=await res.json();
-          if(json.captcha_a && json.captcha_b){
-            const label=document.getElementById('captcha_label');
-            if(label) label.textContent=`What is ${json.captcha_a} + ${json.captcha_b}?`;
-            const input=document.getElementById('captcha'); if(input) input.value='';
-          }
-        }catch(_){}
-      });
-    }
-
-    // Submit
-    document.getElementById('registerForm').addEventListener('submit', async function(e){
-      e.preventDefault();
-      clearAllErrors();
-
-      const data=new FormData(e.target);
-      let valid=true;
-
-      if(!data.get('first_name')){ setErr('firstName','first_name_error','First name is required.'); valid=false; }
-      if(!data.get('last_name')) { setErr('lastName','last_name_error','Last name is required.'); valid=false; }
-      if(!data.get('country'))   { setErr('country','country_error','Country is required.'); valid=false; }
-      if(!data.get('company'))   { setErr('company','company_error','Company is required.'); valid=false; }
-      const isPlanDisabled = planSelect ? planSelect.disabled : false;
-      if(!isPlanDisabled && !data.get('plan_id'))   { setErr('plan','plan_id_error','Plan is required.'); valid=false; }
-
-      const email=data.get('email');
-      if(!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)){
-        setErr('email','email_error','A valid email is required.'); valid=false;
-      }
-
-      const password=data.get('password');
-      if(!password || password.length<6){
-        setErr('password','password_error','Password must be at least 6 characters.'); valid=false;
-      }
-
-      if(!data.get('agreed_terms')){ setErr('terms','agreed_terms_error','You must agree to the terms.'); valid=false; }
-      if(!data.get('captcha'))     { setErr('captcha','captcha_error','Captcha is required.'); valid=false; }
-
-      if(!valid){ showToast('Please correct the errors above.','Validation Error','danger'); return; }
-
-      try{
-        const res=await fetch(@json(route('register.store')),{ method:'POST',
-          headers:{'X-CSRF-TOKEN':document.querySelector('meta[name="csrf-token"]').getAttribute('content'),'Accept':'application/json'},
-          body:data
-        });
-        let result={}; try{ result=await res.json(); }catch(_){}
-
-        if(res.status===422){
-          const map={first_name:'firstName',last_name:'lastName',country:'country',company:'company',plan_id:'plan',email:'email',password:'password',agreed_terms:'terms',captcha:'captcha'};
-          Object.entries(result.errors||{}).forEach(([k,v])=>{
-            const id=map[k]||k; setErr(id,`${k}_error`,Array.isArray(v)?v[0]:v);
-          });
-          showToast('Please correct the errors above.','Validation Error','danger'); return;
-        }
-
-        if(res.ok && result.success){
-          showToast('Registration successful. Redirecting to login...','Success','success');
-          setTimeout(()=> window.location=@json(route('login')),1200);
-        }else{
-          const msg=result.error||'Registration failed.'; showToast(msg,'Error','danger');
-          if((msg||'').toLowerCase().includes('email')){
-            showToast('Already have an account? Click here to log in.','Login','info',4000,()=> window.location=@json(route('login')));
-          }
-        }
-      }catch(_){
-        showToast('Something went wrong. Please try again.','Error','danger');
-      }
-    });
-
-    // Password strength + toggle
-    document.getElementById('password').addEventListener('input', function(){
-      const pw=this.value, bar=document.querySelector('#password-strength .progress-bar'), text=document.getElementById('strength-text');
-      let s=0; if(pw.length>=8) s+=25; if(/[A-Z]/.test(pw)) s+=25; if(/[0-9]/.test(pw)) s+=25; if(/[!@#\$%\^&\*]/.test(pw)) s+=25;
-      bar.style.width=s+'%'; text.textContent=!pw?'':(s<50?'Weak':(s<100?'Medium':'Strong'));
-    });
-    (function(){
-      const toggle=document.getElementById('togglePassword'), input=document.getElementById('password');
-      function togglePw(){ input.type = (input.type==='password') ? 'text' : 'password'; toggle.classList.toggle('bi-eye'); toggle.classList.toggle('bi-eye-slash'); }
-      toggle.addEventListener('click',togglePw);
-      toggle.addEventListener('keypress',e=>{ if(e.key==='Enter'||e.key===' '){ e.preventDefault(); togglePw(); }});
-    })();
-  </script>
+  <script src="{{ asset('assets/assets-auth/js/auth-main.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- extract the inline styling for the auth pages into a shared `auth-style.css` that is loaded by both login and registration views
- add a shared `auth-main.js` bundle that centralises toast helpers, password toggles, and the login/registration form handling logic
- update the login and registration Blade templates to use the new assets and data attributes for URLs instead of inline scripts

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c0a045f483278aef3fc0974d3b58