### PR TITLE
Improve floating select styling on register form

### DIFF
--- a/public/assets/assets-auth/css/auth-style.css
+++ b/public/assets/assets-auth/css/auth-style.css
@@ -107,6 +107,47 @@ body.auth-page {
   color: var(--muted);
 }
 
+.register-page .floating-select .form-select {
+  padding-top: 1.125rem;
+  padding-bottom: .625rem;
+  color: var(--muted);
+}
+
+.register-page .floating-select .form-select option {
+  color: var(--ink);
+}
+
+.register-page .floating-select .form-select option[value=""] {
+  color: var(--muted);
+}
+
+.register-page .floating-select .form-select:focus,
+.register-page .floating-select .form-select:valid {
+  color: var(--ink);
+}
+
+.register-page .floating-select .form-select:disabled {
+  color: var(--muted);
+  background-color: #f9fafb;
+}
+
+.register-page .floating-select .form-select:required:invalid ~ label,
+.register-page .floating-select .form-select:disabled ~ label {
+  opacity: 1;
+  transform: translateY(.55rem);
+  font-size: 1rem;
+}
+
+.register-page .floating-select .form-select:focus ~ label,
+.register-page .floating-select .form-select:valid ~ label {
+  color: var(--muted);
+  transform: scale(.85) translateY(-.5rem) translateX(.15rem);
+}
+
+.register-page .floating-select .form-select:focus ~ label {
+  color: #111;
+}
+
 .auth-page .password-floating .form-control {
   padding-right: 2.25rem;
 }

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -60,7 +60,7 @@
               </div>
             </div>
 
-            <div class="form-floating mb-1 with-icon">
+            <div class="form-floating mb-1 with-icon floating-select">
               <i class="bi bi-globe fi"></i>
               <select name="country" class="form-select" id="country" required>
                 <option value="" disabled selected>Select Country</option>
@@ -79,7 +79,7 @@
             </div>
             <div id="company_error" class="error-message"></div>
 
-            <div class="form-floating mb-1 with-icon">
+            <div class="form-floating mb-1 with-icon floating-select">
               <i class="bi bi-layers fi"></i>
               <select name="plan_id" class="form-select" id="plan" required disabled aria-disabled="true">
                 @if($plans->isNotEmpty())


### PR DESCRIPTION
## Summary
- add a floating-select wrapper to the Country and Plan dropdowns on the registration form
- tune the auth stylesheet so floating selects keep their label inside until a value is chosen and display a muted placeholder state

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c9c3b0991483278d99755ba9b8268c