### PR TITLE
Adjust register select padding

### DIFF
--- a/public/assets/assets-auth/css/auth-style.css
+++ b/public/assets/assets-auth/css/auth-style.css
@@ -65,6 +65,10 @@ body.auth-page {
   transition: all .2s ease;
 }
 
+.register-page .form-select {
+  padding-top: 25px;
+}
+
 .auth-page .form-control:focus,
 .auth-page .form-select:focus {
   border-color: #111;
@@ -108,7 +112,7 @@ body.auth-page {
 }
 
 .register-page .floating-select .form-select {
-  padding-top: 1.125rem;
+  padding-top: 25px;
   padding-bottom: .625rem;
   color: var(--muted);
 }


### PR DESCRIPTION
## Summary
- raise the top padding for register page select inputs to improve label spacing
- align the floating select variant with the new padding to prevent overlap with the label

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c9c62dcd6c832793e9ebf85842b6e7