### PR TITLE
Add cooldown to forgot password email flow

### DIFF
--- a/config/auth.php
+++ b/config/auth.php
@@ -95,7 +95,7 @@ return [
             'provider' => 'users',
             'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
             'expire' => 60,
-            'throttle' => 60,
+            'throttle' => 120,
         ],
     ],
 


### PR DESCRIPTION
## Summary
- add a 2-minute resend cooldown to the forgot password form, including a visible countdown and button disable state
- persist the cooldown in local storage so the timer survives page reloads
- raise the backend password reset throttle to 120 seconds to match the UI timer

## Testing
- php artisan test *(warnings: missing .env for some feature tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ce5eec308327ad070132597429ba