### PR TITLE
Fix Cashfree plan validation mismatch on registration

### DIFF
--- a/app/Http/Controllers/Auth/CashfreeController.php
+++ b/app/Http/Controllers/Auth/CashfreeController.php
@@ -29,9 +29,8 @@ class CashfreeController extends Controller
         ]);
 
         $plan = Plan::findOrFail($validated['plan_id']);
-        $planName = strtolower($plan->name);
 
-        if ($plan->billing_cycle !== 'month' || ! in_array($planName, ['pro', 'business'], true)) {
+        if (! $plan->isCashfreeEligible()) {
             throw ValidationException::withMessages([
                 'plan_id' => 'The selected plan does not support Cashfree payments.',
             ]);

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -87,9 +87,7 @@ class RegisterController extends Controller
                 ]);
             }
 
-            $requiresCashfree = $plan->billing_cycle === 'month'
-                && in_array(strtolower($plan->name), ['pro', 'business'], true)
-                && ((float) $plan->inr_price > 0 || (float) $plan->usd_price > 0);
+            $requiresCashfree = $plan->requiresCashfreePayment();
 
             $paymentData = [
                 'provider' => null,

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -47,6 +47,32 @@ class Plan extends Model
     {
         return $this->monthly_file !== null ? (int) $this->monthly_file : null;
     }
+
+    /**
+     * Determine if the plan can be purchased through Cashfree.
+     */
+    public function isCashfreeEligible(): bool
+    {
+        $name = strtolower(trim((string) $this->name));
+
+        return $this->billing_cycle === 'month'
+            && in_array($name, ['pro', 'business'], true);
+    }
+
+    /**
+     * Check whether Cashfree payment is required for the plan.
+     */
+    public function requiresCashfreePayment(): bool
+    {
+        if (! $this->isCashfreeEligible()) {
+            return false;
+        }
+
+        $inr = (float) $this->inr_price;
+        $usd = (float) $this->usd_price;
+
+        return $inr > 0 || $usd > 0;
+    }
 }
 
 

--- a/public/assets/assets-auth/js/auth-main.js
+++ b/public/assets/assets-auth/js/auth-main.js
@@ -282,8 +282,13 @@
       if (!option || !option.dataset) {
         return false;
       }
+
+      if (typeof option.dataset.cashfreeRequired !== 'undefined') {
+        return option.dataset.cashfreeRequired === '1';
+      }
+
       const billing = option.dataset.billing || '';
-      const name = (option.dataset.name || '').toLowerCase();
+      const name = (option.dataset.name || '').toLowerCase().trim();
       const inr = Number.parseFloat(option.dataset.inrPrice || '0');
       const usd = Number.parseFloat(option.dataset.usdPrice || '0');
       if (billing !== 'month') {

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -116,6 +116,7 @@
                             data-plan="true"
                             data-name="{{ $plan->name }}"
                             data-billing="{{ $plan->billing_cycle }}"
+                            data-cashfree-required="{{ $plan->requiresCashfreePayment() ? '1' : '0' }}"
                             data-inr-price="{{ $plan->inr_price }}"
                             data-usd-price="{{ $plan->usd_price }}">
                       {{ $defaultLabel }}


### PR DESCRIPTION
## Summary
- centralize the Cashfree eligibility logic on the Plan model and reuse it in the registration flow
- expose the payment requirement flag to the registration view so the frontend can rely on the backend value
- update the registration script to read the new flag, keeping Cashfree validation consistent between client and server

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cbc7aa50788327b40f2a5f33c07a16