### PR TITLE
Add post-registration payment flow

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -6,10 +6,12 @@ use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Models\Country;
 use App\Models\Plan;
+use App\Models\UserPlan;
 use App\Rules\Captcha;
 use App\Services\CashfreeService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
 use Carbon\Carbon;
 
@@ -88,71 +90,66 @@ class RegisterController extends Controller
             }
 
             $requiresCashfree = $plan->requiresCashfreePayment();
+            $paymentIsRequired = ((float) $plan->inr_price > 0) || ((float) $plan->usd_price > 0);
+
+            $planStatus = $paymentIsRequired ? 2 : 1;
 
             $paymentData = [
                 'provider' => null,
                 'reference' => null,
                 'amount' => null,
                 'currency' => null,
-                'status' => null,
+                'status' => $paymentIsRequired ? 'PENDING' : 'NOT_REQUIRED',
             ];
 
-            if ($requiresCashfree) {
-                if (! $cashfree->enabled()) {
-                    throw ValidationException::withMessages([
-                        'cashfree' => 'Cashfree payments are currently unavailable. Please try again later or contact support.',
-                    ]);
-                }
-
+            if ($requiresCashfree && $cashfree->enabled()) {
                 $orderId = $validated['cashfree_order_id'] ?? null;
 
-                if (! $orderId) {
-                    throw ValidationException::withMessages([
-                        'cashfree' => 'Payment verification is required for the selected plan.',
-                    ]);
+                if ($orderId) {
+                    try {
+                        $order = $cashfree->getOrder($orderId);
+                    } catch (\RuntimeException $exception) {
+                        throw ValidationException::withMessages([
+                            'cashfree' => 'Unable to verify payment: ' . $exception->getMessage(),
+                        ]);
+                    }
+
+                    $status = strtoupper($order['order_status'] ?? '');
+                    if ($status !== 'PAID') {
+                        throw ValidationException::withMessages([
+                            'cashfree' => 'Cashfree payment has not been completed yet.',
+                        ]);
+                    }
+
+                    $currency = strtoupper($order['order_currency'] ?? '');
+                    $amount = isset($order['order_amount']) ? (float) $order['order_amount'] : null;
+
+                    if (! in_array($currency, ['INR', 'USD'], true) || $amount === null) {
+                        throw ValidationException::withMessages([
+                            'cashfree' => 'Unexpected payment details received from Cashfree.',
+                        ]);
+                    }
+
+                    $expectedAmount = $currency === 'INR'
+                        ? (float) $plan->inr_price
+                        : (float) $plan->usd_price;
+
+                    if (abs($expectedAmount - $amount) > 0.01) {
+                        throw ValidationException::withMessages([
+                            'cashfree' => 'Cashfree payment amount does not match the selected plan.',
+                        ]);
+                    }
+
+                    $paymentData = [
+                        'provider' => 'cashfree',
+                        'reference' => $orderId,
+                        'amount' => round($amount, 2),
+                        'currency' => $currency,
+                        'status' => $status,
+                    ];
+
+                    $planStatus = 1;
                 }
-
-                try {
-                    $order = $cashfree->getOrder($orderId);
-                } catch (\RuntimeException $exception) {
-                    throw ValidationException::withMessages([
-                        'cashfree' => 'Unable to verify payment: ' . $exception->getMessage(),
-                    ]);
-                }
-
-                $status = strtoupper($order['order_status'] ?? '');
-                if ($status !== 'PAID') {
-                    throw ValidationException::withMessages([
-                        'cashfree' => 'Cashfree payment has not been completed yet.',
-                    ]);
-                }
-
-                $currency = strtoupper($order['order_currency'] ?? '');
-                $amount = isset($order['order_amount']) ? (float) $order['order_amount'] : null;
-
-                if (! in_array($currency, ['INR', 'USD'], true) || $amount === null) {
-                    throw ValidationException::withMessages([
-                        'cashfree' => 'Unexpected payment details received from Cashfree.',
-                    ]);
-                }
-
-                $expectedAmount = $currency === 'INR'
-                    ? (float) $plan->inr_price
-                    : (float) $plan->usd_price;
-
-                if (abs($expectedAmount - $amount) > 0.01) {
-                    throw ValidationException::withMessages([
-                        'cashfree' => 'Cashfree payment amount does not match the selected plan.',
-                    ]);
-                }
-
-                $paymentData = [
-                    'provider' => 'cashfree',
-                    'reference' => $orderId,
-                    'amount' => round($amount, 2),
-                    'currency' => $currency,
-                    'status' => $status,
-                ];
             }
 
             $start = Carbon::today();
@@ -167,7 +164,7 @@ class RegisterController extends Controller
                 'plan_id'    => $plan->id,
                 'start_date' => $start->toDateString(),
                 'end_date'   => $end,
-                'status'     => 1,
+                'status'     => $planStatus,
                 'payment_provider' => $paymentData['provider'],
                 'payment_reference' => $paymentData['reference'],
                 'payment_amount' => $paymentData['amount'],
@@ -183,10 +180,15 @@ class RegisterController extends Controller
             $b = random_int(1, 9);
             session(['captcha_answer' => $a + $b]);
 
+            $redirectUrl = URL::temporarySignedRoute('register.payment', now()->addMinutes(30), [
+                'user' => $user->id,
+            ]);
+
             return response()->json([
                 'success'   => true,
                 'captcha_a' => $a,
                 'captcha_b' => $b,
+                'redirect_url' => $redirectUrl,
             ]);
         } catch (\Illuminate\Validation\ValidationException $ve) {
             DB::rollBack();
@@ -203,5 +205,141 @@ class RegisterController extends Controller
 
             return response()->json(['error' => 'Registration failed'], 500);
         }
+    }
+
+    public function payment(Request $request, CashfreeService $cashfree, User $user)
+    {
+        if (! $request->hasValidSignature()) {
+            abort(403);
+        }
+
+        $userPlan = UserPlan::where('user_id', $user->id)
+            ->latest('id')
+            ->with('plan')
+            ->first();
+
+        if (! $userPlan || ! $userPlan->plan) {
+            abort(404);
+        }
+
+        $plan = $userPlan->plan;
+        $paymentIsRequired = ((float) $plan->inr_price > 0) || ((float) $plan->usd_price > 0);
+        $paymentPending = $paymentIsRequired && strtoupper((string) $userPlan->payment_status) !== 'PAID';
+
+        $cashfreeConfig = [
+            'enabled' => $cashfree->enabled(),
+            'mode' => $cashfree->mode(),
+            'order_url' => $cashfree->enabled() ? route('register.cashfree.order') : null,
+        ];
+
+        $completeUrl = null;
+        if ($cashfreeConfig['enabled'] && $plan->requiresCashfreePayment() && $paymentPending) {
+            $completeUrl = URL::temporarySignedRoute(
+                'register.payment.complete',
+                now()->addMinutes(30),
+                ['user' => $user->id, 'plan' => $plan->id]
+            );
+        }
+
+        return view('auth.payment', [
+            'user' => $user,
+            'plan' => $plan,
+            'userPlan' => $userPlan,
+            'requiresPayment' => $paymentPending,
+            'cashfree' => $cashfreeConfig,
+            'completeUrl' => $completeUrl,
+        ]);
+    }
+
+    public function completePayment(Request $request, CashfreeService $cashfree, User $user, Plan $plan)
+    {
+        if (! $request->hasValidSignature()) {
+            abort(403);
+        }
+
+        $validated = $request->validate([
+            'order_id' => ['required', 'string', 'max:100'],
+        ]);
+
+        $userPlan = UserPlan::where('user_id', $user->id)
+            ->where('plan_id', $plan->id)
+            ->latest('id')
+            ->first();
+
+        if (! $userPlan) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Subscription record not found for this account.',
+            ], 404);
+        }
+
+        if (! $plan->requiresCashfreePayment()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'This plan does not require a Cashfree payment.',
+            ], 422);
+        }
+
+        if (! $cashfree->enabled()) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Cashfree payments are currently unavailable. Please try again later.',
+            ], 422);
+        }
+
+        try {
+            $order = $cashfree->getOrder($validated['order_id']);
+        } catch (\RuntimeException $exception) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Unable to verify payment: ' . $exception->getMessage(),
+            ], 422);
+        }
+
+        $status = strtoupper($order['order_status'] ?? '');
+        if ($status !== 'PAID') {
+            return response()->json([
+                'success' => false,
+                'message' => 'Cashfree has not confirmed this payment yet.',
+            ], 422);
+        }
+
+        $currency = strtoupper($order['order_currency'] ?? '');
+        $amount = isset($order['order_amount']) ? (float) $order['order_amount'] : null;
+
+        if (! in_array($currency, ['INR', 'USD'], true) || $amount === null) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Unexpected payment details received from Cashfree.',
+            ], 422);
+        }
+
+        $expectedAmount = $currency === 'INR'
+            ? (float) $plan->inr_price
+            : (float) $plan->usd_price;
+
+        if (abs($expectedAmount - $amount) > 0.01) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Cashfree payment amount does not match the selected plan.',
+            ], 422);
+        }
+
+        DB::table('user_plans')
+            ->where('id', $userPlan->id)
+            ->update([
+                'status' => 1,
+                'payment_provider' => 'cashfree',
+                'payment_reference' => $validated['order_id'],
+                'payment_amount' => round($amount, 2),
+                'payment_currency' => $currency,
+                'payment_status' => $status,
+                'updated_at' => now(),
+            ]);
+
+        return response()->json([
+            'success' => true,
+            'redirect_url' => route('login'),
+        ]);
     }
 }

--- a/public/assets/assets-auth/js/auth-main.js
+++ b/public/assets/assets-auth/js/auth-main.js
@@ -821,11 +821,6 @@
       const selectedPlanOption = getSelectedPlanOption();
       const paymentRequired = requiresCashfreePayment(selectedPlanOption);
 
-      if (paymentRequired && !cashfreeState.paid) {
-        setError('plan', 'cashfree_error', 'Please complete the Cashfree payment to continue.');
-        valid = false;
-      }
-
       const email = data.get('email');
       if (!email || !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(email)) {
         setError('email', 'email_error', 'A valid email is required.');
@@ -917,13 +912,17 @@
         }
 
         if (response.ok && result.success) {
-          showToast('Registration successful. Redirecting to login...', {
+          const redirectTarget = result.redirect_url || loginUrl;
+          const message = redirectTarget && redirectTarget !== loginUrl
+            ? 'Registration successful. Redirecting to payment...'
+            : 'Registration successful. Redirecting to login...';
+          showToast(message, {
             title: 'Success',
             variant: 'success'
           });
-          if (loginUrl) {
+          if (redirectTarget) {
             setTimeout(() => {
-              window.location = loginUrl;
+              window.location = redirectTarget;
             }, 1200);
           }
         } else {

--- a/public/assets/assets-auth/js/payment-page.js
+++ b/public/assets/assets-auth/js/payment-page.js
@@ -1,0 +1,192 @@
+(() => {
+  const container = document.getElementById('paymentApp');
+  if (!container) {
+    return;
+  }
+
+  const {
+    planId = '',
+    firstName = '',
+    lastName = '',
+    email = '',
+    company = '',
+    country = '',
+    cashfreeEnabled = '0',
+    cashfreeMode = 'sandbox',
+    cashfreeOrderUrl = '',
+    completeUrl = '',
+    loginUrl = '',
+    requiresPayment = '0',
+  } = container.dataset;
+
+  const needsPayment = requiresPayment === '1';
+  const cashfreeActive = cashfreeEnabled === '1';
+  const statusElement = container.querySelector('[data-payment-status]');
+  const statusBaseClass = statusElement ? (statusElement.dataset.baseClass || statusElement.className || 'alert') : 'alert';
+  const currencyButtons = container.querySelectorAll('[data-pay-currency]');
+  const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+
+  const setStatus = (message, variant = 'info') => {
+    if (!statusElement) {
+      return;
+    }
+
+    statusElement.className = statusBaseClass;
+
+    if (!message) {
+      statusElement.classList.add('d-none');
+      statusElement.textContent = '';
+      return;
+    }
+
+    statusElement.classList.remove('d-none');
+    statusElement.classList.remove('alert-primary', 'alert-secondary', 'alert-success', 'alert-danger', 'alert-warning', 'alert-info', 'alert-light', 'alert-dark');
+    statusElement.classList.add(`alert-${variant}`);
+    statusElement.textContent = message;
+  };
+
+  const toggleButtons = (disabled, activeButton = null) => {
+    currencyButtons.forEach((button) => {
+      button.disabled = disabled;
+      if (disabled) {
+        button.classList.add('disabled');
+      } else {
+        button.classList.remove('disabled');
+      }
+    });
+
+    if (disabled && activeButton) {
+      activeButton.classList.add('disabled');
+    }
+  };
+
+  const requestJson = async (url, payload) => {
+    const headers = { Accept: 'application/json', 'Content-Type': 'application/json' };
+    if (csrfToken) {
+      headers['X-CSRF-TOKEN'] = csrfToken;
+    }
+
+    const response = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload || {}),
+    });
+
+    const json = await response.json().catch(() => ({}));
+    return { response, json };
+  };
+
+  let cashfreeInstance = null;
+  const ensureCashfreeInstance = () => {
+    if (!cashfreeActive) {
+      return null;
+    }
+
+    if (cashfreeInstance) {
+      return cashfreeInstance;
+    }
+
+    if (typeof window !== 'undefined' && window.Cashfree) {
+      try {
+        cashfreeInstance = new window.Cashfree({ mode: cashfreeMode === 'production' ? 'production' : 'sandbox' });
+      } catch (error) {
+        cashfreeInstance = null;
+      }
+    }
+
+    return cashfreeInstance;
+  };
+
+  if (!needsPayment) {
+    toggleButtons(true);
+    setStatus('', 'info');
+    return;
+  }
+
+  if (!cashfreeActive || !cashfreeOrderUrl || !completeUrl) {
+    toggleButtons(true);
+    setStatus('Online payments are currently unavailable. Please contact support to complete your subscription.', 'danger');
+    return;
+  }
+
+  const handleCheckout = async (rawCurrency, button) => {
+    const currency = (rawCurrency || '').toUpperCase();
+    if (!currency) {
+      return;
+    }
+
+    toggleButtons(true, button);
+    setStatus('Preparing secure payment...', 'info');
+
+    try {
+      const { response, json } = await requestJson(cashfreeOrderUrl, {
+        plan_id: planId,
+        currency,
+        first_name: firstName,
+        last_name: lastName,
+        email,
+        country,
+        company,
+      });
+
+      if (!response.ok || !json || !json.success) {
+        const message = json?.message
+          || (json?.errors && Object.values(json.errors).flat().join(' '))
+          || json?.error
+          || 'Unable to initiate the payment. Please try again.';
+        setStatus(message, 'danger');
+        return;
+      }
+
+      const sessionId = json.payment_session_id;
+      const orderId = json.order_id;
+      const instance = ensureCashfreeInstance();
+
+      if (!instance || !sessionId || !orderId) {
+        setStatus('Unable to open the payment gateway. Please try again.', 'danger');
+        return;
+      }
+
+      let checkoutCancelled = false;
+      await instance.checkout({
+        paymentSessionId: sessionId,
+        redirectTarget: '_modal',
+      }).catch((error) => {
+        checkoutCancelled = true;
+        const message = error?.message || 'Payment was cancelled before completion.';
+        setStatus(message, 'danger');
+      });
+
+      if (checkoutCancelled) {
+        return;
+      }
+
+      setStatus('Verifying payment...', 'info');
+      const completion = await requestJson(completeUrl, { order_id: orderId });
+
+      if (!completion.response.ok || !completion.json || !completion.json.success) {
+        const message = completion.json?.message || 'Payment could not be confirmed. Please try again.';
+        setStatus(message, 'danger');
+        return;
+      }
+
+      const redirectTarget = completion.json.redirect_url || loginUrl;
+      setStatus('Payment successful! Redirecting...', 'success');
+      if (redirectTarget) {
+        setTimeout(() => {
+          window.location = redirectTarget;
+        }, 1500);
+      }
+    } catch (error) {
+      setStatus(error?.message || 'Unable to process the payment. Please try again.', 'danger');
+    } finally {
+      toggleButtons(false);
+    }
+  };
+
+  currencyButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      handleCheckout(button.dataset.payCurrency || '', button);
+    });
+  });
+})();

--- a/resources/views/auth/payment.blade.php
+++ b/resources/views/auth/payment.blade.php
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Complete Payment</title>
+  <meta name="csrf-token" content="{{ csrf_token() }}">
+
+  {{-- Favicons --}}
+  <link rel="apple-touch-icon" sizes="180x180" href="{{ asset('assets/favicon_io/apple-touch-icon.png') }}">
+  <link rel="icon" type="image/png" sizes="32x32" href="{{ asset('assets/favicon_io/favicon-32x32.png') }}">
+  <link rel="icon" type="image/png" sizes="16x16" href="{{ asset('assets/favicon_io/favicon-16x16.png') }}">
+  <link rel="manifest" href="{{ asset('assets/favicon_io/site.webmanifest') }}">
+  <link rel="shortcut icon" href="{{ asset('assets/favicon_io/favicon.ico') }}">
+
+  <!-- Fonts & Vendors -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+
+  <link rel="stylesheet" href="{{ asset('assets/assets-auth/css/auth-style.css') }}">
+</head>
+@php
+  $billingCycle = strtolower($plan->billing_cycle ?? '');
+  $billingLabel = match ($billingCycle) {
+    'month' => 'Monthly',
+    'year' => 'Yearly',
+    default => 'One-time',
+  };
+  $inrAmount = (float) ($plan->inr_price ?? 0);
+  $usdAmount = (float) ($plan->usd_price ?? 0);
+  $hasInr = $inrAmount > 0;
+  $hasUsd = $usdAmount > 0;
+  $pendingPayment = (bool) ($requiresPayment ?? false);
+
+  $formatAmount = function (float $amount, string $currency): string {
+    $decimals = abs($amount - round($amount)) > 0.0001 ? 2 : 0;
+    $formatted = number_format($amount, $decimals);
+    return match ($currency) {
+      'INR' => '₹' . $formatted,
+      'USD' => '$' . $formatted,
+      default => $currency . ' ' . $formatted,
+    };
+  };
+
+  $statusValue = strtoupper((string) $userPlan->payment_status);
+  [$statusText, $statusClass] = match ($statusValue) {
+    'PAID' => ['Payment completed', 'bg-success'],
+    'NOT_REQUIRED' => ['No payment required', 'bg-success'],
+    'PENDING' => ['Payment pending', 'bg-warning text-dark'],
+    default => ['Pending confirmation', 'bg-secondary'],
+  };
+@endphp
+<body class="auth-page payment-page d-flex align-items-center min-vh-100">
+  <div class="container py-5">
+    <div class="row justify-content-center">
+      <div class="col-lg-7 col-md-9">
+        <div class="card card-container">
+          <h3 class="text-center mb-2">Complete Your Subscription</h3>
+          <p class="text-center text-muted mb-3">Thank you, {{ $user->first_name }}. One more step to activate your plan.</p>
+
+          <div id="paymentApp"
+               data-plan-id="{{ $plan->id }}"
+               data-first-name="{{ $user->first_name }}"
+               data-last-name="{{ $user->last_name }}"
+               data-email="{{ $user->email }}"
+               data-company="{{ $user->company ?? '' }}"
+               data-country="{{ $user->country ?? '' }}"
+               data-cashfree-enabled="{{ $cashfree['enabled'] ? '1' : '0' }}"
+               data-cashfree-mode="{{ $cashfree['mode'] }}"
+               data-cashfree-order-url="{{ $cashfree['order_url'] ?? '' }}"
+               data-complete-url="{{ $completeUrl ?? '' }}"
+               data-login-url="{{ route('login') }}"
+               data-requires-payment="{{ $pendingPayment ? '1' : '0' }}">
+            <div class="border rounded p-3 mb-3">
+              <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+                <div>
+                  <h5 class="mb-1">{{ $plan->name }}</h5>
+                  <p class="text-muted mb-0">Billing: {{ $billingLabel }}</p>
+                </div>
+                <span class="badge {{ $statusClass }} px-3 py-2">{{ $statusText }}</span>
+              </div>
+              <hr>
+              <ul class="list-unstyled mb-0">
+                <li class="mb-1"><strong>Plan ID:</strong> {{ $plan->id }}</li>
+                @if($hasInr)
+                  <li class="mb-1"><strong>Amount (INR):</strong> {{ $formatAmount($inrAmount, 'INR') }}{{ $billingCycle ? ' / ' . strtolower($billingLabel) : '' }}</li>
+                @endif
+                @if($hasUsd)
+                  <li class="mb-1"><strong>Amount (USD):</strong> {{ $formatAmount($usdAmount, 'USD') }}{{ $billingCycle ? ' / ' . strtolower($billingLabel) : '' }}</li>
+                @endif
+                @unless($hasInr || $hasUsd)
+                  <li class="mb-1"><strong>Amount:</strong> <span class="badge bg-success">Free</span></li>
+                @endunless
+              </ul>
+            </div>
+
+            @if($pendingPayment)
+              <div class="mb-3">
+                <h5 class="mb-2">Choose payment currency</h5>
+                <p class="text-muted mb-3">Click Pay Now to complete your subscription securely. You can select INR or USD based on your preference.</p>
+                @if(!($cashfree['enabled'] ?? false) || empty($cashfree['order_url'] ?? null) || empty($completeUrl))
+                  <div class="alert alert-warning" role="alert">
+                    Online payments are currently unavailable. Please contact support to complete your subscription.
+                  </div>
+                @endif
+                <div class="d-flex flex-wrap gap-2">
+                  @if($hasInr)
+                    <button type="button" class="btn btn-primary" data-pay-currency="INR">
+                      <span class="d-flex align-items-center">
+                        <i class="bi bi-credit-card me-2"></i>
+                        <span>Pay Now ({{ $formatAmount($inrAmount, 'INR') }})</span>
+                      </span>
+                    </button>
+                  @endif
+                  @if($hasUsd)
+                    <button type="button" class="btn btn-outline-primary" data-pay-currency="USD">
+                      <span class="d-flex align-items-center">
+                        <i class="bi bi-credit-card me-2"></i>
+                        <span>Pay Now ({{ $formatAmount($usdAmount, 'USD') }})</span>
+                      </span>
+                    </button>
+                  @endif
+                </div>
+                <div class="alert d-none mt-3" data-base-class="alert mt-3" data-payment-status role="alert"></div>
+              </div>
+            @else
+              @if($statusValue === 'PAID')
+                <div class="alert alert-success" role="alert">
+                  Your payment has been received. You can continue to sign in and start using your account.
+                </div>
+              @else
+                <div class="alert alert-success" role="alert">
+                  This plan does not require a payment. You can continue to sign in and start using your account.
+                </div>
+              @endif
+            @endif
+
+            <div class="d-flex flex-column flex-md-row justify-content-between gap-2 mt-4">
+              <a href="{{ route('home') }}" class="btn btn-outline-secondary w-100 w-md-auto">
+                <i class="bi bi-arrow-left"></i> Back to Home
+              </a>
+              <a href="{{ route('login') }}" class="btn btn-success w-100 w-md-auto">
+                Go to Login
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  @if(($cashfree['enabled'] ?? false) && $requiresPayment)
+    <script src="https://sdk.cashfree.com/js/ui/2.0.0/cashfree.js"></script>
+  @endif
+  <script src="{{ asset('assets/assets-auth/js/payment-page.js') }}"></script>
+</body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,12 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('guest')->group(function () {
     Route::get('/register', [RegisterController::class, 'create'])->name('register');
     Route::post('/register', [RegisterController::class, 'store'])->name('register.store');
+    Route::get('/register/payment/{user}', [RegisterController::class, 'payment'])
+        ->middleware('signed')
+        ->name('register.payment');
+    Route::post('/register/payment/{user}/{plan}/complete', [RegisterController::class, 'completePayment'])
+        ->middleware('signed')
+        ->name('register.payment.complete');
     Route::post('/register/captcha', [ContactController::class, 'refreshCaptcha'])->name('register.captcha');
     Route::post('/register/cashfree/order', [CashfreeController::class, 'createOrder'])->name('register.cashfree.order');
     Route::post('/register/cashfree/verify', [CashfreeController::class, 'verifyOrder'])->name('register.cashfree.verify');


### PR DESCRIPTION
## Summary
- add signed routes and controller actions to serve a post-registration payment screen and record Cashfree confirmations
- allow registration to succeed without an upfront Cashfree payment while tracking pending status and redirecting to the payment screen
- implement a standalone payment page with Cashfree checkout helpers and update the registration script to redirect there after success

## Testing
- php artisan test *(passes with warnings about missing `.env` file)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd1202a408327ba4e809b3c2e7d1c