### PR TITLE
Enable Cashfree payment for yearly plans

### DIFF
--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -55,7 +55,7 @@ class Plan extends Model
     {
         $name = strtolower(trim((string) $this->name));
 
-        return $this->billing_cycle === 'month'
+        return in_array($this->billing_cycle, ['month', 'year'], true)
             && in_array($name, ['pro', 'business'], true);
     }
 

--- a/public/assets/assets-auth/js/auth-main.js
+++ b/public/assets/assets-auth/js/auth-main.js
@@ -287,11 +287,11 @@
         return option.dataset.cashfreeRequired === '1';
       }
 
-      const billing = option.dataset.billing || '';
+      const billing = (option.dataset.billing || '').toLowerCase();
       const name = (option.dataset.name || '').toLowerCase().trim();
       const inr = Number.parseFloat(option.dataset.inrPrice || '0');
       const usd = Number.parseFloat(option.dataset.usdPrice || '0');
-      if (billing !== 'month') {
+      if (!['month', 'year'].includes(billing)) {
         return false;
       }
       if (!['pro', 'business'].includes(name)) {


### PR DESCRIPTION
## Summary
- allow yearly Pro and Business plans to be considered Cashfree-eligible on the server
- update the registration page script so yearly paid plans also trigger the Cashfree payment notice

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68cbd6b6b44c8327933897f233176aa9