### PR TITLE
Auto login after registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -10,7 +10,9 @@ use App\Models\UserPlan;
 use App\Rules\Captcha;
 use App\Services\CashfreeService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Validation\ValidationException;
 use Carbon\Carbon;
@@ -175,6 +177,13 @@ class RegisterController extends Controller
             ]);
 
             DB::commit();
+
+            Auth::login($user);
+            $request->session()->regenerate();
+
+            Session::put('user_id', $user->id);
+            Session::put('user_name', $user->first_name ?? $user->name ?? '');
+            Session::put('use_id', $user->use_id ?? null);
 
             $a = random_int(1, 9);
             $b = random_int(1, 9);

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,15 +32,7 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('guest')->group(function () {
     Route::get('/register', [RegisterController::class, 'create'])->name('register');
     Route::post('/register', [RegisterController::class, 'store'])->name('register.store');
-    Route::get('/register/payment/{user}', [RegisterController::class, 'payment'])
-        ->middleware('signed')
-        ->name('register.payment');
-    Route::post('/register/payment/{user}/{plan}/complete', [RegisterController::class, 'completePayment'])
-        ->middleware('signed')
-        ->name('register.payment.complete');
     Route::post('/register/captcha', [ContactController::class, 'refreshCaptcha'])->name('register.captcha');
-    Route::post('/register/cashfree/order', [CashfreeController::class, 'createOrder'])->name('register.cashfree.order');
-    Route::post('/register/cashfree/verify', [CashfreeController::class, 'verifyOrder'])->name('register.cashfree.verify');
 
     Route::get('/login', [LoginController::class, 'create'])->name('login');
     Route::post('/login', [LoginController::class, 'store'])->name('login.store');
@@ -50,6 +42,15 @@ Route::middleware('guest')->group(function () {
     Route::get('/reset-password/{token}', [PasswordResetController::class, 'reset'])->name('password.reset');
     Route::post('/reset-password', [PasswordResetController::class, 'update'])->name('password.update');
 });
+
+Route::get('/register/payment/{user}', [RegisterController::class, 'payment'])
+    ->middleware('signed')
+    ->name('register.payment');
+Route::post('/register/payment/{user}/{plan}/complete', [RegisterController::class, 'completePayment'])
+    ->middleware('signed')
+    ->name('register.payment.complete');
+Route::post('/register/cashfree/order', [CashfreeController::class, 'createOrder'])->name('register.cashfree.order');
+Route::post('/register/cashfree/verify', [CashfreeController::class, 'verifyOrder'])->name('register.cashfree.verify');
 
 Route::post('/analytics/track', [AnalyticsWebController::class, 'track'])->name('analytics.track');
 


### PR DESCRIPTION
## Summary
- log in new users immediately after registration and mirror the session data that the login endpoint sets
- allow payment completion and Cashfree order routes to be accessed after registration by moving them outside the guest middleware group

## Testing
- `php artisan test` (warnings: missing `.env` file in test environment)


------
https://chatgpt.com/codex/tasks/task_e_68cbddab6be88327bd7f160607cbcf14