### PR TITLE
Fix Cashfree endpoints using base URL

### DIFF
--- a/app/Services/CashfreeService.php
+++ b/app/Services/CashfreeService.php
@@ -95,7 +95,7 @@ class CashfreeService
      */
     public function createOrder(array $payload): array
     {
-        $response = $this->client()->post('/orders', $payload);
+        $response = $this->client()->post('orders', $payload);
 
         if ($response->failed()) {
             $message = $this->extractErrorMessage($response->json(), $response->body());
@@ -110,7 +110,7 @@ class CashfreeService
      */
     public function getOrder(string $orderId): array
     {
-        $response = $this->client()->get("/orders/{$orderId}");
+        $response = $this->client()->get("orders/{$orderId}");
 
         if ($response->failed()) {
             $message = $this->extractErrorMessage($response->json(), $response->body());


### PR DESCRIPTION
## Summary
- ensure Cashfree service requests use the configured base URL path when calling the orders API

## Testing
- php artisan test *(fails: vendor directory not present in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe673ef9883278484fbaf60622156