### PR TITLE
Add mobile number handling to registration payment flow

### DIFF
--- a/app/Http/Controllers/Auth/CashfreeController.php
+++ b/app/Http/Controllers/Auth/CashfreeController.php
@@ -24,6 +24,7 @@ class CashfreeController extends Controller
             'first_name' => ['required', 'string', 'max:255'],
             'last_name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'email', 'max:255'],
+            'mobile' => ['required', 'string', 'max:20', 'regex:/^[0-9+()\-\s]{6,20}$/'],
             'country' => ['nullable', 'string', 'max:255'],
             'company' => ['nullable', 'string', 'max:255'],
         ]);
@@ -60,6 +61,13 @@ class CashfreeController extends Controller
         }
 
         $customerName = trim($validated['first_name'] . ' ' . $validated['last_name']);
+        $phoneDigits = preg_replace('/\D+/', '', $validated['mobile']);
+        $digitLength = is_string($phoneDigits) ? strlen($phoneDigits) : 0;
+        if ($digitLength < 6 || $digitLength > 15) {
+            throw ValidationException::withMessages([
+                'mobile' => 'Please provide a valid mobile number.',
+            ]);
+        }
         $payload = [
             'order_id' => $orderId,
             'order_amount' => round($amount, 2),
@@ -68,6 +76,7 @@ class CashfreeController extends Controller
                 'customer_id' => $customerId,
                 'customer_name' => $customerName,
                 'customer_email' => $validated['email'],
+                'customer_phone' => $phoneDigits !== '' ? substr($phoneDigits, 0, 15) : null,
             ]),
             'order_note' => sprintf('OneLinkPDF %s (%s)', $plan->name, strtoupper($plan->billing_cycle)),
         ];

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -153,6 +153,13 @@
             </div>
             <div id="email_error" class="error-message"></div>
 
+            <div class="form-floating mb-1 with-icon">
+              <i class="bi bi-telephone fi"></i>
+              <input type="tel" name="mobile" class="form-control" id="mobile" placeholder="Mobile number" inputmode="tel" autocomplete="tel">
+              <label for="mobile">Mobile number</label>
+            </div>
+            <div id="mobile_error" class="error-message"></div>
+
             <div class="form-floating mb-1 position-relative password-floating with-icon">
               <i class="bi bi-lock fi"></i>
               <input type="password" name="password" class="form-control" id="password" placeholder="Password" required minlength="6" autocomplete="off">


### PR DESCRIPTION
## Summary
- add a mobile number field to the registration form UI
- validate the mobile number on the client when required and include it in Cashfree order creation
- require and sanitize the mobile number on the server before completing paid registrations and Cashfree orders

## Testing
- php artisan test *(warnings: missing .env configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cbefedd798832782c05bd508ecbc79