### PR TITLE
Include mobile number in payment payload

### DIFF
--- a/public/assets/assets-auth/js/payment-page.js
+++ b/public/assets/assets-auth/js/payment-page.js
@@ -9,6 +9,7 @@
     firstName = '',
     lastName = '',
     email = '',
+    mobile = '',
     company = '',
     country = '',
     cashfreeEnabled = '0',
@@ -117,6 +118,7 @@
 
     toggleButtons(true, button);
     setStatus('Preparing secure payment...', 'info');
+    const sanitizedMobile = (mobile || '').trim();
 
     try {
       const { response, json } = await requestJson(cashfreeOrderUrl, {
@@ -125,6 +127,7 @@
         first_name: firstName,
         last_name: lastName,
         email,
+        mobile: sanitizedMobile,
         country,
         company,
       });

--- a/resources/views/auth/payment.blade.php
+++ b/resources/views/auth/payment.blade.php
@@ -66,6 +66,7 @@
                data-first-name="{{ $user->first_name }}"
                data-last-name="{{ $user->last_name }}"
                data-email="{{ $user->email }}"
+               data-mobile="{{ $user->mobile ?? '' }}"
                data-company="{{ $user->company ?? '' }}"
                data-country="{{ $user->country ?? '' }}"
                data-cashfree-enabled="{{ $cashfree['enabled'] ? '1' : '0' }}"


### PR DESCRIPTION
## Summary
- expose the user's mobile number in the payment view so the checkout script can access it
- include the sanitized mobile number when creating the Cashfree order payload on the payment page

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cbf71e50648327865cbbba9d1c0e03