### PR TITLE
Store user mobile number during registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -72,6 +72,8 @@ class RegisterController extends Controller
             $useId = str_pad(random_int(0, 99999999), 8, '0', STR_PAD_LEFT)
                    . str_pad(random_int(0, 99999999), 8, '0', STR_PAD_LEFT);
 
+            $mobile = trim((string) ($validated['mobile'] ?? ''));
+
             $user = User::create([
                 'use_id'       => $useId,
                 'country'      => $validated['country'],
@@ -93,7 +95,6 @@ class RegisterController extends Controller
                 ]);
             }
 
-            $mobile = trim((string) ($validated['mobile'] ?? ''));
             if ($plan->requiresCashfreePayment() && $cashfree->enabled() && $mobile === '') {
                 throw ValidationException::withMessages([
                     'mobile' => 'Mobile number is required to complete payment for this plan.',

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -79,6 +79,7 @@ class RegisterController extends Controller
                 'last_name'    => $validated['last_name'],
                 'company'      => $validated['company'],
                 'email'        => $validated['email'],
+                'mobile'       => $mobile !== '' ? $mobile : null,
                 'password'     => $validated['password'],
                 'agreed_terms' => true,
             ]);

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -31,6 +31,7 @@ class UserFactory extends Factory
             'last_name' => $last,
             'country' => fake()->country(),
             'company' => fake()->company(),
+            'mobile' => fake()->numerify('##########'),
             'name' => "$first $last",
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),

--- a/database/migrations/2025_09_18_000001_add_mobile_to_users_table.php
+++ b/database/migrations/2025_09_18_000001_add_mobile_to_users_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('users', 'mobile')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('mobile', 20)->nullable()->after('email');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('users', 'mobile')) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->dropColumn('mobile');
+            });
+        }
+    }
+};

--- a/public/assets/assets-auth/js/payment-page.js
+++ b/public/assets/assets-auth/js/payment-page.js
@@ -116,9 +116,14 @@
       return;
     }
 
+    const sanitizedMobile = (mobile || '').replace(/\D+/g, '').slice(0, 15);
+    if (sanitizedMobile.length < 6) {
+      setStatus('A valid mobile number is required before continuing to payment.', 'danger');
+      return;
+    }
+
     toggleButtons(true, button);
     setStatus('Preparing secure payment...', 'info');
-    const sanitizedMobile = (mobile || '').trim();
 
     try {
       const { response, json } = await requestJson(cashfreeOrderUrl, {

--- a/resources/views/auth/payment.blade.php
+++ b/resources/views/auth/payment.blade.php
@@ -66,7 +66,7 @@
                data-first-name="{{ $user->first_name }}"
                data-last-name="{{ $user->last_name }}"
                data-email="{{ $user->email }}"
-               data-mobile="{{ $user->mobile ?? '' }}"
+               data-mobile="{{ $paymentMobile ?? '' }}"
                data-company="{{ $user->company ?? '' }}"
                data-country="{{ $user->country ?? '' }}"
                data-cashfree-enabled="{{ $cashfree['enabled'] ? '1' : '0' }}"


### PR DESCRIPTION
## Summary
- persist the registrant's mobile number on the User record so it can populate payment payloads

## Testing
- php artisan test

------
https://chatgpt.com/codex/tasks/task_e_68cbfe9e5f6883279d55217ed7688c16