### PR TITLE
Adjust Cashfree headers for authentication

### DIFF
--- a/app/Services/CashfreeService.php
+++ b/app/Services/CashfreeService.php
@@ -70,7 +70,8 @@ class CashfreeService
 
         $this->client = Http::baseUrl($this->baseUrl())
             ->withHeaders($this->authenticationHeaders($appId, $secret))
-            ->acceptJson();
+            ->acceptJson()
+            ->asJson();
 
         return $this->client;
     }
@@ -89,15 +90,12 @@ class CashfreeService
 
     protected function authenticationHeaders(string $appId, string $secret): array
     {
-        $headers = [
+        return [
             'x-client-id' => $appId,
             'x-client-secret' => $secret,
             'x-api-version' => $this->apiVersion(),
+            'Content-Type' => 'application/json',
         ];
-
-        $headers['Authorization'] = 'Basic ' . base64_encode("{$appId}:{$secret}");
-
-        return $headers;
     }
 
     /**

--- a/tests/Unit/CashfreeServiceTest.php
+++ b/tests/Unit/CashfreeServiceTest.php
@@ -49,10 +49,8 @@ class CashfreeServiceTest extends TestCase
         $this->assertTrue($capturedRequest->hasHeader('x-client-secret', 'test-secret'));
         $this->assertTrue($capturedRequest->hasHeader('x-api-version', '2027-03-15'));
 
-        $this->assertSame(
-            ['Basic ' . base64_encode('test-app:test-secret')],
-            $capturedRequest->header('Authorization')
-        );
+        $this->assertTrue($capturedRequest->hasHeader('Content-Type', 'application/json'));
+        $this->assertTrue($capturedRequest->hasHeader('Accept', 'application/json'));
 
         Http::assertSentCount(1);
     }


### PR DESCRIPTION
## Summary
- update the Cashfree HTTP client to send JSON headers without the unused Basic Authorization value
- ensure JSON requests are encoded correctly by default when hitting the Cashfree API
- refresh the Cashfree service unit test to assert the new header expectations

## Testing
- php artisan test


------
https://chatgpt.com/codex/tasks/task_e_68cc1070be4c8327ade712b94a4f40a0