### PR TITLE
Fix Cashfree checkout initialization timing

### DIFF
--- a/public/assets/assets-auth/js/auth-main.js
+++ b/public/assets/assets-auth/js/auth-main.js
@@ -219,7 +219,9 @@
     const cashfreeCurrencyInput = document.getElementById('cashfreeCurrency');
     const cashfreeAmountInput = document.getElementById('cashfreeAmount');
     const cashfreeError = document.getElementById('cashfree_error');
+    const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
     let cashfreeInstance = null;
+    let cashfreeInstancePromise = null;
     let cashfreeState = {
       planId: null,
       paid: false,
@@ -348,21 +350,92 @@
       cashfreeStatus.classList.add(toneClass);
     };
 
-    const ensureCashfreeInstance = () => {
+    const resolveCashfreeConstructor = () => {
+      if (typeof window === 'undefined') {
+        return null;
+      }
+
+      let ctor = window.Cashfree || window.cashfree || null;
+      if (ctor && typeof ctor === 'object' && typeof ctor.Cashfree === 'function') {
+        ctor = ctor.Cashfree;
+      }
+
+      return typeof ctor === 'function' ? ctor : null;
+    };
+
+    const attemptInstantiateCashfree = async () => {
+      const ctor = resolveCashfreeConstructor();
+      if (!ctor) {
+        return null;
+      }
+
+      const options = { mode: cashfreeMode === 'production' ? 'production' : 'sandbox' };
+
+      const tryBuild = (factory, useNew = false) => {
+        try {
+          const instance = useNew ? new factory(options) : factory(options);
+          return instance;
+        } catch (error) {
+          const message = typeof error?.message === 'string' ? error.message : '';
+          if (!useNew && /class constructor/i.test(message)) {
+            return tryBuild(factory, true);
+          }
+
+          return null;
+        }
+      };
+
+      let candidate = tryBuild(ctor, false);
+      if (!candidate) {
+        candidate = tryBuild(ctor, true);
+      }
+
+      if (candidate && typeof candidate.then === 'function') {
+        try {
+          const awaited = await candidate;
+          return awaited && typeof awaited.checkout === 'function' ? awaited : null;
+        } catch (error) {
+          return null;
+        }
+      }
+
+      return candidate && typeof candidate.checkout === 'function' ? candidate : null;
+    };
+
+    const ensureCashfreeInstance = async () => {
       if (!cashfreeEnabled) {
         return null;
       }
-      if (cashfreeInstance) {
+
+      if (cashfreeInstance && typeof cashfreeInstance.checkout === 'function') {
         return cashfreeInstance;
       }
-      if (window.Cashfree) {
-        try {
-          cashfreeInstance = new window.Cashfree({ mode: cashfreeMode === 'production' ? 'production' : 'sandbox' });
-        } catch (error) {
-          cashfreeInstance = null;
-        }
+
+      if (cashfreeInstancePromise) {
+        return cashfreeInstancePromise;
       }
-      return cashfreeInstance;
+
+      const loadInstance = async () => {
+        for (let attempt = 0; attempt < 4; attempt += 1) {
+          const instance = await attemptInstantiateCashfree();
+          if (instance && typeof instance.checkout === 'function') {
+            return instance;
+          }
+
+          await wait(200 * (attempt + 1));
+        }
+
+        return null;
+      };
+
+      cashfreeInstancePromise = loadInstance().then((instance) => {
+        cashfreeInstance = instance && typeof instance.checkout === 'function' ? instance : null;
+        return cashfreeInstance;
+      }).finally(() => {
+        cashfreeInstancePromise = null;
+      });
+
+      return cashfreeInstancePromise;
     };
 
     const updateCashfreePlanSummary = (option, needsPayment) => {
@@ -645,11 +718,11 @@
         }
 
         const { payment_session_id: sessionId, order_id: orderId, order_amount: orderAmount } = json;
-        const instance = ensureCashfreeInstance();
+        const instance = await ensureCashfreeInstance();
 
         if (!instance || !sessionId || !orderId) {
-          setCashfreeStatus('Unable to open Cashfree checkout. Please try again.', 'danger');
-          showToast('Unable to open Cashfree checkout. Please try again.', {
+          setCashfreeStatus('Unable to load Cashfree checkout right now. Please refresh and try again.', 'danger');
+          showToast('Unable to load Cashfree checkout right now. Please refresh and try again.', {
             title: 'Payment error',
             variant: 'danger',
           });

--- a/public/assets/assets-auth/js/payment-page.js
+++ b/public/assets/assets-auth/js/payment-page.js
@@ -26,6 +26,7 @@
   const statusBaseClass = statusElement ? (statusElement.dataset.baseClass || statusElement.className || 'alert') : 'alert';
   const currencyButtons = container.querySelectorAll('[data-pay-currency]');
   const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '';
+  const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
   const setStatus = (message, variant = 'info') => {
     if (!statusElement) {
@@ -78,24 +79,94 @@
   };
 
   let cashfreeInstance = null;
-  const ensureCashfreeInstance = () => {
+  let cashfreeInstancePromise = null;
+
+  const resolveCashfreeConstructor = () => {
+    if (typeof window === 'undefined') {
+      return null;
+    }
+
+    let ctor = window.Cashfree || window.cashfree || null;
+    if (ctor && typeof ctor === 'object' && typeof ctor.Cashfree === 'function') {
+      ctor = ctor.Cashfree;
+    }
+
+    return typeof ctor === 'function' ? ctor : null;
+  };
+
+  const attemptInstantiateCashfree = async () => {
+    const ctor = resolveCashfreeConstructor();
+    if (!ctor) {
+      return null;
+    }
+
+    const options = { mode: cashfreeMode === 'production' ? 'production' : 'sandbox' };
+
+    const tryBuild = (factory, useNew = false) => {
+      try {
+        const instance = useNew ? new factory(options) : factory(options);
+        return instance;
+      } catch (error) {
+        const message = typeof error?.message === 'string' ? error.message : '';
+        if (!useNew && /class constructor/i.test(message)) {
+          return tryBuild(factory, true);
+        }
+
+        return null;
+      }
+    };
+
+    let candidate = tryBuild(ctor, false);
+    if (!candidate) {
+      candidate = tryBuild(ctor, true);
+    }
+
+    if (candidate && typeof candidate.then === 'function') {
+      try {
+        const awaited = await candidate;
+        return awaited && typeof awaited.checkout === 'function' ? awaited : null;
+      } catch (error) {
+        return null;
+      }
+    }
+
+    return candidate && typeof candidate.checkout === 'function' ? candidate : null;
+  };
+
+  const ensureCashfreeInstance = async () => {
     if (!cashfreeActive) {
       return null;
     }
 
-    if (cashfreeInstance) {
+    if (cashfreeInstance && typeof cashfreeInstance.checkout === 'function') {
       return cashfreeInstance;
     }
 
-    if (typeof window !== 'undefined' && window.Cashfree) {
-      try {
-        cashfreeInstance = new window.Cashfree({ mode: cashfreeMode === 'production' ? 'production' : 'sandbox' });
-      } catch (error) {
-        cashfreeInstance = null;
-      }
+    if (cashfreeInstancePromise) {
+      return cashfreeInstancePromise;
     }
 
-    return cashfreeInstance;
+    const loadInstance = async () => {
+      for (let attempt = 0; attempt < 4; attempt += 1) {
+        const instance = await attemptInstantiateCashfree();
+        if (instance && typeof instance.checkout === 'function') {
+          return instance;
+        }
+
+        await wait(200 * (attempt + 1));
+      }
+
+      return null;
+    };
+
+    cashfreeInstancePromise = loadInstance().then((instance) => {
+      cashfreeInstance = instance && typeof instance.checkout === 'function' ? instance : null;
+      return cashfreeInstance;
+    }).finally(() => {
+      cashfreeInstancePromise = null;
+    });
+
+    return cashfreeInstancePromise;
   };
 
   if (!needsPayment) {
@@ -148,10 +219,10 @@
 
       const sessionId = json.payment_session_id;
       const orderId = json.order_id;
-      const instance = ensureCashfreeInstance();
+      const instance = await ensureCashfreeInstance();
 
       if (!instance || !sessionId || !orderId) {
-        setStatus('Unable to open the payment gateway. Please try again.', 'danger');
+        setStatus('Unable to load the payment gateway right now. Please refresh and try again.', 'danger');
         return;
       }
 


### PR DESCRIPTION
## Summary
- add a reusable async Cashfree bootstrapper on the standalone payment page so we wait for the SDK before attempting checkout
- update the registration form Cashfree flow to share the async initialisation logic and surface clearer messaging when checkout cannot start

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc131821dc83279c20517f69c2fed2